### PR TITLE
Gameplay upgrades: infinite world, terrain, water, persistence, Minecraft UI

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -5,24 +5,32 @@ import TitleScreen from "./components/UIComponents/TitleScreen";
 import CoreGame from "./components/CoreGame";
 
 function App() {
-  const establishedConn = useOnlineConnection();
   const [playerConfigReady, setPCR] = useState(false);
+  const establishedConn = useOnlineConnection(playerConfigReady);
 
-  function playerGivenGameSettings(obj) {
-    settings.movewithJOY_BOOL = obj.movewithJOY_BOOL;
+  // Called by the title screen once the player has picked name/seed/mode.
+  function playerGivenGameSettings(config) {
+    settings.movewithJOY_BOOL = config.movewithJOY_BOOL;
+    settings.onlineEnabled = config.onlineEnabled;
+    if (config.playerName) {
+      settings.playerName = config.playerName;
+    }
+    if (config.seed) {
+      settings.worldSettings.seed = config.seed;
+    }
     setPCR(true);
+  }
+
+  if (!playerConfigReady) {
+    return <TitleScreen playerGivenGameSettings={playerGivenGameSettings} />;
   }
 
   if (!establishedConn) {
     //waiting screen while connecting to the online server
-    return <div>Connecting to multiplayer server...</div>;
+    return <div className="connecting-screen">Connecting to server...</div>;
   }
 
-  return playerConfigReady ? (
-    <CoreGame />
-  ) : (
-    <TitleScreen playerGivenGameSettings={playerGivenGameSettings} />
-  );
+  return <CoreGame />;
 }
 
 export default App;

--- a/src/components/CoreGame.js
+++ b/src/components/CoreGame.js
@@ -34,7 +34,7 @@ const CoreGame = () => {
   const activeTextureREF = useRef("dirt");
   const chunksMadeCounter = useRef({
     loaddone: false,
-    track: { count: 0, max: settings.worldSettings.worldSize ** 2 },
+    track: { count: 0, max: 0 }, // max is set once the initial fill is queued
   });
   const [initStatus, setInitStatus] = useState({
     buildWorkers: 0,
@@ -71,6 +71,15 @@ const CoreGame = () => {
         <></>
       )}
       <Canvas>
+        {/* fog hides the chunk-loading edge; far matches the view radius */}
+        <fog
+          attach="fog"
+          args={[
+            "#d7e7f5",
+            settings.viewRadius * settings.worldSettings.chunkSize * 0.55,
+            settings.viewRadius * settings.worldSettings.chunkSize * 0.98,
+          ]}
+        />
         {showFPS && <Stats />}
         <PerformanceMonitor
           onIncline={() =>

--- a/src/components/CoreGame.js
+++ b/src/components/CoreGame.js
@@ -7,6 +7,7 @@ import { Scene } from "./Scene";
 import settings from "../constants";
 import { OrbitControls } from "@react-three/drei";
 import { LoadingWorldScreen } from "./UIComponents/LoadingWorldScreen";
+import PauseOverlay from "./UIComponents/PauseOverlay";
 import LowerControlStrip from "../hooks/LowerControlStrip";
 import { useRef, useState } from "react";
 import { useControls } from "leva";
@@ -45,13 +46,11 @@ const CoreGame = () => {
   // live debug panel -- tweak render toggles here while playing
   const {
     showUIContent,
-    showTextureSelector,
     showFPS,
     showSky,
     orbitalControlsEnabled,
   } = useControls({
     showUIContent: { value: false, label: "show UI content" },
-    showTextureSelector: { value: false, label: "show texture selector" },
     showFPS: { value: true, label: "show FPS" },
     showSky: { value: true, label: "show sky" },
     orbitalControlsEnabled: { value: false, label: "orbital controls" },
@@ -112,9 +111,8 @@ const CoreGame = () => {
       {!settings.ignoreCameraFollowPlayer && (
         <div className="cursor centered absolute">+</div>
       )}
-      {showTextureSelector && (
-        <TextureSelector activeTextureREF={activeTextureREF} />
-      )}
+      <TextureSelector activeTextureREF={activeTextureREF} />
+      <PauseOverlay />
     </>
   );
 };

--- a/src/components/Scene.js
+++ b/src/components/Scene.js
@@ -1,24 +1,8 @@
-import { useState, useRef } from "react";
+import { useRef } from "react";
 import { Player } from "./playerComponents/Player";
 import { OtherPlayers } from "./playerComponents/OtherPlayers";
 import settings from "../constants";
 import { Cubes } from "./cubeComponents/Cubes";
-import { chunkIdFromPosition } from "../world/chunkMath";
-
-function setupPlayerStartingPosition() {
-  let sp = settings.startingPositionDefault;
-  if (settings.randomizeStartPos) {
-    const fulllength =
-      settings.worldSettings.chunkSize * settings.worldSettings.worldSize;
-    sp = [fulllength / 2, settings.startingPositionDefault[1], fulllength / 2];
-    settings.startingChunk = chunkIdFromPosition(
-      sp[0],
-      sp[2],
-      settings.worldSettings,
-    );
-  }
-  return sp;
-}
 
 export const Scene = ({
   activeTextureREF,
@@ -27,7 +11,7 @@ export const Scene = ({
   moveBools,
 }) => {
   const REF_ALLCUBES = useRef({});
-  const [playerStartPos] = useState(setupPlayerStartingPosition);
+  const playerStartPos = settings.startingPositionDefault;
 
   return (
     <>
@@ -45,6 +29,7 @@ export const Scene = ({
           REF_ALLCUBES={REF_ALLCUBES}
           updateInitStatus={updateInitStatus}
           chunksMadeCounter={chunksMadeCounter}
+          spawnPos={playerStartPos}
         />
       )}
     </>

--- a/src/components/TextureSelector.js
+++ b/src/components/TextureSelector.js
@@ -13,6 +13,9 @@ const images = {
 
 const texturesArray = Object.keys(images);
 
+// 9 hotbar slots: first 5 have textures, last 4 are empty
+const HOTBAR_SLOTS = 9;
+
 export const TextureSelector = ({ activeTextureREF }) => {
   const [activeTexture, setTexture] = useStore((state) => [
     state.texture,
@@ -49,18 +52,30 @@ export const TextureSelector = ({ activeTextureREF }) => {
     return () => {
       window.removeEventListener("wheel", handleWheel);
     };
-  }, [setTexture, dirt, grass, glass, wood, log, activeTexture]);
+  }, [setTexture, dirt, grass, glass, wood, log, activeTexture, activeTextureREF]);
+
+  const slots = Array.from({ length: HOTBAR_SLOTS }, (_, i) => {
+    const key = texturesArray[i] || null;
+    return { key, src: key ? images[key] : null };
+  });
 
   return (
-    <div className="absolute centered-bottom texture-selector">
-      {Object.entries(images).map(([k, src]) => {
+    <div className="hotbar">
+      {slots.map((slot, i) => {
+        const isActive = slot.key === activeTexture;
         return (
-          <img
-            key={k}
-            src={src}
-            alt={k}
-            className={`${k === activeTexture ? "active" : ""}`}
-          />
+          <div
+            key={i}
+            className={`hotbar__slot${isActive ? " hotbar__slot--active" : ""}`}
+          >
+            {slot.src && (
+              <img
+                src={slot.src}
+                alt={slot.key}
+                className="hotbar__img"
+              />
+            )}
+          </div>
         );
       })}
     </div>

--- a/src/components/UIComponents/LoadingWorldScreen.js
+++ b/src/components/UIComponents/LoadingWorldScreen.js
@@ -1,40 +1,71 @@
 import { useEffect, useRef, useState } from "react";
+import { dirtImg } from "../../images/images";
 
 export const LoadingWorldScreen = ({ buildWorkers, chunksMadeCounter }) => {
-  const [timeSoFar, setTSF] = useState(0);
-  const loadingScreenHtmlRef = useRef();
+  const [tick, setTick] = useState(0);
+  const [visible, setVisible] = useState(true);
+  const [fadeOut, setFadeOut] = useState(false);
+  const intervalRef = useRef(null);
 
+  // Wire the imperative contract: chunksMadeCounter.current.ref = { ref, updateDisplay }
+  // updateDisplay triggers a re-render via setTick so the progress bar updates.
   useEffect(() => {
-    if (!chunksMadeCounter.current.loaddone) {
-      setTimeout(() => setTSF(timeSoFar + 1), 1000);
+    function updateDisplay() {
+      setTick((t) => t + 1);
     }
-    if (loadingScreenHtmlRef.current) {
-      // console.log(loadingScreenHtmlRef.current.children[0].textContent)
-      chunksMadeCounter.current["ref"] = {
-        ref: loadingScreenHtmlRef.current,
-        updateDisplay: updateDisplay,
-      };
 
-      // console.log(loadingScreenHtmlRef.current.children)
+    chunksMadeCounter.current["ref"] = {
+      ref: null, // not needed for DOM manipulation any more
+      updateDisplay,
+    };
+
+    // Backup poll in case updateDisplay stops being called after loaddone
+    intervalRef.current = setInterval(() => {
+      if (chunksMadeCounter.current.loaddone) {
+        setTick((t) => t + 1);
+      }
+    }, 250);
+
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, []); // chunksMadeCounter is a stable ref — no dep needed
+
+  // When loaddone goes true, start the fade-out then unmount
+  useEffect(() => {
+    if (chunksMadeCounter.current.loaddone && !fadeOut) {
+      setFadeOut(true);
+      const t = setTimeout(() => setVisible(false), 600);
+      return () => clearTimeout(t);
     }
-  }, [timeSoFar]);
+  });
 
-  function updateDisplay() {
-    loadingScreenHtmlRef.current.children[0].textContent = `load done - ${
-      chunksMadeCounter.current.loaddone ? "true" : "false"
-    } -- ${chunksMadeCounter.current.track.count}/${
-      chunksMadeCounter.current.track.max
-    }`;
-    // loadingScreenHtmlRef.current.children[1].textContent = ``
-    // loadingScreenHtmlRef.current.children[2].textContent = ``
-  }
+  if (!visible) return null;
+
+  const track = chunksMadeCounter.current.track;
+  const pct =
+    track.max > 0 ? Math.min(100, Math.round((track.count / track.max) * 100)) : 0;
 
   return (
-    <div ref={loadingScreenHtmlRef}>
-      <div id="loadingpage"></div>
-      <div id="loadingpage">Building Workers {buildWorkers}</div>
-      <div id="loadingpage">
-        Load Time So Far: <span>{timeSoFar}</span>s
+    <div
+      className={`loading-screen${fadeOut ? " loading-screen--fade" : ""}`}
+      style={{ backgroundImage: `url(${dirtImg})` }}
+    >
+      <div className="loading-screen__overlay" />
+      <div className="loading-screen__content">
+        <h2 className="loading-screen__title">Building world...</h2>
+        <div className="loading-screen__bar-track">
+          <div
+            className="loading-screen__bar-fill"
+            style={{ width: `${pct}%` }}
+          />
+        </div>
+        <div className="loading-screen__pct">{pct}%</div>
+        {buildWorkers > 0 && (
+          <div className="loading-screen__workers">
+            Workers ready: {buildWorkers}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/UIComponents/PauseOverlay.js
+++ b/src/components/UIComponents/PauseOverlay.js
@@ -1,0 +1,97 @@
+import { useEffect, useState } from "react";
+import settings from "../../constants";
+
+const CONTROLS = [
+  ["WASD", "Move"],
+  ["Space", "Jump"],
+  ["Double-tap W", "Sprint"],
+  ["Left click", "Place block"],
+  ["Right click", "Break block"],
+  ["1-5 / Wheel", "Select block"],
+  ["Esc", "Pause"],
+];
+
+function requestLock() {
+  const canvas = document.querySelector("canvas");
+  if (canvas) canvas.requestPointerLock();
+}
+
+const PauseOverlay = () => {
+  const [locked, setLocked] = useState(false);
+  const [hasBeenLocked, setHasBeenLocked] = useState(false);
+
+  useEffect(() => {
+    function onLockChange() {
+      const isLocked = !!document.pointerLockElement;
+      setLocked(isLocked);
+      if (isLocked) setHasBeenLocked(true);
+    }
+
+    document.addEventListener("pointerlockchange", onLockChange);
+    return () => document.removeEventListener("pointerlockchange", onLockChange);
+  }, []);
+
+  // Don't render anything on touch/joystick devices
+  if (settings.movewithJOY_BOOL) return null;
+
+  // Pointer is locked — game is running, no overlay needed
+  if (locked) return null;
+
+  const isPaused = hasBeenLocked;
+
+  return (
+    <div
+      className="pause-overlay"
+      onClick={requestLock}
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") requestLock();
+      }}
+    >
+      <div className="pause-overlay__panel" onClick={(e) => e.stopPropagation()}>
+        <h2 className="pause-overlay__title">
+          {isPaused ? "Game Paused" : "Click to play"}
+        </h2>
+
+        {!isPaused && (
+          <table className="pause-overlay__controls">
+            <tbody>
+              {CONTROLS.map(([key, action]) => (
+                <tr key={key}>
+                  <td className="pause-overlay__key">{key}</td>
+                  <td className="pause-overlay__action">{action}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+
+        {isPaused && (
+          <div className="pause-overlay__btn-row">
+            <button
+              className="mc-play-btn"
+              onClick={requestLock}
+            >
+              Back to Game
+            </button>
+            <button
+              className="mc-play-btn mc-play-btn--danger"
+              onClick={() => window.location.reload()}
+            >
+              Quit to Title
+            </button>
+          </div>
+        )}
+
+        {!isPaused && (
+          <button className="mc-play-btn pause-overlay__click-btn" onClick={requestLock}>
+            Click to Start
+          </button>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default PauseOverlay;

--- a/src/components/UIComponents/TitleScreen.js
+++ b/src/components/UIComponents/TitleScreen.js
@@ -1,64 +1,82 @@
+import { useState } from "react";
+import { dirtImg } from "../../images/images";
+
 const TitleScreen = ({ playerGivenGameSettings }) => {
+  const [name, setName] = useState("Player");
+  const [seed, setSeed] = useState("robo");
+  const [mode, setMode] = useState("singleplayer");
+
   function handleClickPlay() {
-    // small screens get the touch joystick controls
-    playerGivenGameSettings({ movewithJOY_BOOL: window.innerWidth < 400 });
+    playerGivenGameSettings({
+      movewithJOY_BOOL: window.innerWidth < 400,
+      onlineEnabled: mode === "multiplayer",
+      playerName: name.trim() || "Player",
+      seed: seed.trim() || "robo",
+    });
   }
 
   return (
-    <>
-      <div className="TitleCard_Container">
-        <div
-          className="TitleCard_ColorBlock"
-          style={{ backgroundColor: "#395E2B", height: "6.25%" }}
-        />
-        <div
-          className="TitleCard_ColorBlock"
-          style={{ backgroundColor: "#457537", height: "6.25%" }}
-        />
-        <div
-          className="TitleCard_ColorBlock"
-          style={{ backgroundColor: "#4D8B40", height: "6.25%" }}
-        />
-        <div
-          className="TitleCard_ColorBlock"
-          style={{ backgroundColor: "#70B443", height: "6.25%" }}
-        />
-        <div
-          className="TitleCard_ColorBlock"
-          style={{ backgroundColor: "#84502B", height: "25%" }}
-        >
-          <div
-            className="text-center minecraft-text2"
-            style={{ fontSize: "min(75px,14vw)" }}
-          >
-            CloneCraft
+    <div className="title-screen">
+      <div className="title-screen__bg" style={{ backgroundImage: `url(${dirtImg})` }} />
+      <div className="title-screen__overlay" />
+
+      <div className="title-screen__content">
+        <h1 className="title-screen__logo">CloneCraft</h1>
+
+        <div className="title-screen__panel">
+          <div className="mc-field">
+            <label className="mc-label" htmlFor="ts-name">
+              Player Name
+            </label>
+            <input
+              id="ts-name"
+              className="mc-input"
+              type="text"
+              value={name}
+              maxLength={16}
+              onChange={(e) => setName(e.target.value)}
+            />
           </div>
-        </div>
-        <div
-          className="TitleCard_ColorBlock"
-          style={{ backgroundColor: "#A1663A", height: "25%" }}
-        >
-          <div
-            className="minecraft-text3 text-center"
-            style={{ fontSize: "min(50px,9vw)" }}
-          >
-            A MineCraft Clone
+
+          <div className="mc-field">
+            <label className="mc-label" htmlFor="ts-seed">
+              World Seed
+            </label>
+            <input
+              id="ts-seed"
+              className="mc-input"
+              type="text"
+              value={seed}
+              maxLength={32}
+              onChange={(e) => setSeed(e.target.value)}
+            />
           </div>
-        </div>
-        <div
-          className="TitleCard_ColorBlock"
-          style={{ backgroundColor: "#C27F48", height: "25%" }}
-        >
-          <input
-            type="button"
-            value={"PLAY"}
-            onClick={() => {
-              handleClickPlay();
-            }}
-          />
+
+          <div className="mc-field">
+            <div className="mc-mode-row">
+              <button
+                className={`mc-mode-btn${mode === "singleplayer" ? " mc-mode-btn--active" : ""}`}
+                onClick={() => setMode("singleplayer")}
+              >
+                Singleplayer
+              </button>
+              <button
+                className={`mc-mode-btn${mode === "multiplayer" ? " mc-mode-btn--active" : ""}`}
+                onClick={() => setMode("multiplayer")}
+              >
+                Multiplayer
+              </button>
+            </div>
+          </div>
+
+          <button className="mc-play-btn" onClick={handleClickPlay}>
+            PLAY
+          </button>
         </div>
       </div>
-    </>
+
+      <div className="title-screen__footer">CloneCraft — a Minecraft clone</div>
+    </div>
   );
 };
 

--- a/src/components/cubeComponents/Chunk.jsx
+++ b/src/components/cubeComponents/Chunk.jsx
@@ -1,28 +1,25 @@
 import { useFrame, useThree } from "@react-three/fiber";
 import { FormCubeArrays } from "./FormCubeArrays";
 import * as THREE from "three";
-import { useRef } from "react";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import settings from "../../constants";
 import { makeKey } from "../../world/keys";
 import { useStore } from "../../hooks/useStore";
 
 export const Chunk = ({
-  chunkNum,
+  chunkKey,
   activeTextureREF,
   chunkProps,
   REF_ALLCUBES,
-  addWorkerJob,
+  applyBlockChange,
 }) => {
   const { camera, scene } = useThree();
+  const chunkTrackVisibility = useRef(false);
+  const [updateChunk, setUpdateChunk] = useState(false);
   const [online_addCube, online_removeCube] = useStore((state) => [
     state.online_addCube,
     state.online_removeCube,
   ]);
-  const chunkTrackBlockCount = useRef(0);
-  const chunkTrackVisibility = useRef(false);
-  const [updateChunk, setUpdateChunk] = useState(false);
-  let firstPass = useRef(true);
 
   function clickCubeFace(e) {
     e.stopPropagation();
@@ -44,47 +41,43 @@ export const Chunk = ({
     });
 
     if (intersect.length > 0) {
-      let currBlocks = REF_ALLCUBES.current;
-      let faceNormal = [
+      const faceNormal = [
         intersect[0].face.normal.x,
         intersect[0].face.normal.y,
         intersect[0].face.normal.z,
       ];
-      let contactBlock = [...intersect[0].point].map((val, ind) => {
+      const contactBlock = [...intersect[0].point].map((val, ind) => {
         return Math.round(val + 0.000002 * faceNormal[ind] * -1);
       });
 
-      let currTexture = activeTextureREF.current;
-
       if (e.button === 0) {
-        let blockToAdd = contactBlock.map((val, ind) => {
+        const blockToAdd = contactBlock.map((val, ind) => {
           return val + faceNormal[ind];
         });
-        let newblock = {
-          key: makeKey(...blockToAdd),
-          pos: blockToAdd,
-        };
-        currBlocks[newblock.key] = { pos: newblock.pos, texture: currTexture };
-        chunkProps.current[chunkNum].keys.push(newblock.key);
-        chunkProps.current[chunkNum].count++;
+        const texture = activeTextureREF.current;
+        // can't place a block inside yourself
+        const [px, py, pz] = camera.position;
+        if (
+          Math.abs(blockToAdd[0] - px) < 0.8 &&
+          Math.abs(blockToAdd[2] - pz) < 0.8 &&
+          blockToAdd[1] > py - 2 &&
+          blockToAdd[1] < py + 0.5
+        ) {
+          return;
+        }
+        applyBlockChange({ type: "add", pos: blockToAdd, texture });
         if (settings.onlineEnabled) {
-          online_addCube(newblock.pos, currTexture);
+          online_addCube(blockToAdd, texture);
         }
       }
 
       if (e.button === 2) {
-        const remove = makeKey(...contactBlock);
-        if (!(remove in currBlocks)) {
+        const key = makeKey(...contactBlock);
+        const block = REF_ALLCUBES.current[key];
+        if (!block || block.texture === "bedrock") {
           return;
         }
-        delete currBlocks[remove];
-        const keys = chunkProps.current[chunkNum].keys;
-        const r_index = keys.indexOf(remove);
-        if (r_index !== -1) {
-          keys[r_index] = keys[keys.length - 1];
-          keys.pop();
-        }
-        chunkProps.current[chunkNum].count--;
+        applyBlockChange({ type: "remove", pos: contactBlock });
         if (settings.onlineEnabled) {
           online_removeCube(contactBlock);
         }
@@ -93,40 +86,29 @@ export const Chunk = ({
   }
 
   useFrame(() => {
-    if (chunkProps.current[chunkNum].count !== chunkTrackBlockCount.current) {
-      chunkTrackBlockCount.current = chunkProps.current[chunkNum].count;
-      if (firstPass.current) {
-        firstPass.current = false;
-      } else {
-        addWorkerJob(chunkNum, "user");
-      }
+    const chunk = chunkProps.current[chunkKey];
+    if (!chunk) {
+      return;
     }
-    if (chunkProps.current[chunkNum].draw.rere) {
-      chunkProps.current[chunkNum].draw.rere = false;
+    if (chunk.draw.rere) {
+      chunk.draw.rere = false;
       setUpdateChunk(!updateChunk); //triggers a rerender
     }
-    if (chunkProps.current[chunkNum].visible !== chunkTrackVisibility.current) {
-      chunkTrackVisibility.current = chunkProps.current[chunkNum].visible;
+    if (chunk.visible !== chunkTrackVisibility.current) {
+      chunkTrackVisibility.current = chunk.visible;
       setUpdateChunk(!updateChunk);
     }
   });
 
-  function handleEmpty() {
-    if (
-      chunkTrackBlockCount.current > 0 &&
-      chunkProps.current[chunkNum].visible
-    ) {
-      return (
-        <FormCubeArrays
-          chunkNum={chunkNum}
-          chunkProps={chunkProps.current[chunkNum]}
-          clickCubeFace={clickCubeFace}
-        />
-      );
-    } else {
-      return <></>;
-    }
+  const chunk = chunkProps.current[chunkKey];
+  if (!chunk || !chunk.visible || !chunk.count) {
+    return null;
   }
-
-  return handleEmpty();
+  return (
+    <FormCubeArrays
+      chunkKey={chunkKey}
+      chunkProps={chunk}
+      clickCubeFace={clickCubeFace}
+    />
+  );
 };

--- a/src/components/cubeComponents/Cubes.jsx
+++ b/src/components/cubeComponents/Cubes.jsx
@@ -3,61 +3,53 @@ import { Chunk } from "./Chunk";
 import { useFrame, useThree } from "@react-three/fiber";
 import settings from "../../constants";
 import {
-  chunkIdFromPosition,
+  chunkKeyFromPosition,
   distBetweenChunks,
-  getNearbyChunkIds,
+  getNearbyChunkKeys,
 } from "../../world/chunkMath";
 import { makeKey } from "../../world/keys";
 import { setRemoteBlockApplier } from "../../world/remoteBlocks";
+import { recordEdit, editsForChunks, loadEdits } from "../../world/edits";
 
 export const Cubes = ({
   activeTextureREF,
   REF_ALLCUBES,
   updateInitStatus,
   chunksMadeCounter,
+  spawnPos,
 }) => {
   const { camera } = useThree();
   const [FillerLoadDoneValue, setFillerLoadDone] = useState(false);
-  let viewRadius = settings.viewRadius; //this number is distance from current place chunks are allowed to be shown
-  let outerViewRadius = settings.outerViewRadius; //this number is the distance from current place we insure are built/ready to be shown
-  let fillBatchSize = settings.fillBatchSize; // chunks allowed per worker job
-  let worldSettings = settings.worldSettings;
-  let renderDistPrecentage = settings.renderDistPrecentage;
+  const [chunkKeyList, setChunkKeyList] = useState([]);
+  const viewRadius = settings.viewRadius; //distance (in chunks) chunks are shown
+  const outerViewRadius = settings.outerViewRadius; //distance (in chunks) we ensure are built
+  const fillBatchSize = settings.fillBatchSize; // chunks allowed per worker job
+  const worldSettings = settings.worldSettings;
+  const renderDistPrecentage = settings.renderDistPrecentage;
 
   // i believe for most machines 4 workers is the effective limit but i am using 3 to be safe
-  let workerCount = settings.workerCount; //a set number of workers
+  const workerCount = settings.workerCount;
   const workerPendingJob = useRef([]);
   const workerWorking = useRef(new Array(workerCount).fill(true));
   const workerList = useRef(new Array(workerCount).fill(""));
 
-  const lastRenderChunk = useRef(settings.startingChunk);
-
-  const chunks = useRef(
-    new Array(worldSettings.worldSize ** 2).fill().map(() => {
-      return new Object({ count: 0, draw: { cc: 0, rere: false } });
-    }),
+  const spawnChunk = chunkKeyFromPosition(
+    spawnPos[0],
+    spawnPos[2],
+    worldSettings.chunkSize,
   );
-
-  /* 
-    example
-    chunks.current is whats  below
-      [{
-        keys: [0.0.0,0.0.1,...]
-        count: ####
-        draw:{ cc,vertices, uvs, normals,rere}
-      }
-      ,...] 
-  */
-
+  const lastRenderChunk = useRef(spawnChunk);
+  const chunks = useRef({}); // chunkKey -> {keys, count, visible, draw}
+  const pendingFill = useRef(new Set()); // chunks queued but not yet generated
   const activeChunks = useRef([]);
-  const playerChunkPosition = useRef(-1);
+  const playerChunkPosition = useRef("");
 
   const buildWorker = (id) => {
     const worker = new Worker(
       new URL("../../workers/chunkWorker.js", import.meta.url),
     );
     worker.onerror = (err) => {
-      console.log("myWorker Error:", err);
+      console.error("worker error:", err);
     };
 
     //responsible for handeling the workers response
@@ -66,7 +58,7 @@ export const Cubes = ({
         handleWorkerUserChangeResponse(e.data.regFlow);
       } else if (e.data.worldFiller) {
         chunksMadeCounter.current.track.count +=
-          e.data.worldFiller.chunkNumbers.length;
+          e.data.worldFiller.chunkKeys.length;
         if (chunksMadeCounter.current.ref) {
           chunksMadeCounter.current.ref.updateDisplay();
         }
@@ -82,26 +74,28 @@ export const Cubes = ({
   };
 
   function handleWorkerUserChangeResponse(data) {
-    let { vertices, uvs, normals, count, chunkNumber } = data;
-    vertices = new Float32Array(vertices);
-    uvs = new Float32Array(uvs);
-    normals = new Float32Array(normals);
-    chunks.current[chunkNumber].draw = {
+    const { draw, count, chunkKey } = data;
+    if (!chunks.current[chunkKey]) {
+      return;
+    }
+    chunks.current[chunkKey].draw = {
       cc: count,
-      vertices,
-      uvs,
-      normals,
+      solid: draw.solid,
+      trans: draw.trans,
       rere: true,
     };
-    // worker.terminate(); //use to kill the workers // unsure if we ever have too
   }
 
   function handleWorkerWorldFillResponse(worldFiller) {
     Object.assign(REF_ALLCUBES.current, worldFiller.ac);
 
-    worldFiller.chunkNumbers.forEach((cn) => {
-      chunks.current[cn] = worldFiller.testor[cn];
+    worldFiller.chunkKeys.forEach((ck) => {
+      chunks.current[ck] = worldFiller.testor[ck];
+      pendingFill.current.delete(ck);
     });
+    setChunkKeyList((prev) => [...prev, ...worldFiller.chunkKeys]);
+    updateDisplayedChunks(playerChunkPosition.current || spawnChunk);
+
     if (workerPendingJob.current.length == 0) {
       chunksMadeCounter.current.loaddone = true;
       if (chunksMadeCounter.current.ref) {
@@ -111,29 +105,33 @@ export const Cubes = ({
     }
   }
 
-  function giveWorkerUserChangeJob(workerId, chunkinfo) {
-    let chunkNumber = chunkinfo;
-    let t = 0.5;
-    let adjacentchunks = getNearbyChunkIds(
-      chunkNumber,
-      1,
-      worldSettings.worldSize,
-    );
-    let neededblocks = {};
-    adjacentchunks.forEach((cn) => {
-      chunks.current[cn].keys.forEach((bn) => {
-        neededblocks[bn] = REF_ALLCUBES.current[bn];
-      });
+  function giveWorkerUserChangeJob(workerId, chunkKey) {
+    const t = 0.5;
+    const neededblocks = {};
+    getNearbyChunkKeys(chunkKey, 1.5).forEach((ck) => {
+      if (chunks.current[ck]) {
+        chunks.current[ck].keys.forEach((bn) => {
+          neededblocks[bn] = REF_ALLCUBES.current[bn];
+        });
+      }
     });
-    let blocks = neededblocks;
-    let chunkBlocks = chunks.current[chunkNumber];
     workerList.current[workerId].postMessage({
-      userChange: { t, blocks, chunkBlocks, chunkNumber },
+      userChange: {
+        t,
+        blocks: neededblocks,
+        chunkBlocks: chunks.current[chunkKey],
+        chunkKey,
+      },
     });
   }
 
   function giveWorkerWorldFillJob(workerId, chunkinfo) {
-    workerList.current[workerId].postMessage({ worldFill: chunkinfo.arr });
+    workerList.current[workerId].postMessage({
+      worldFill: {
+        chunks: chunkinfo.arr,
+        edits: editsForChunks(chunkinfo.arr, worldSettings.chunkSize),
+      },
+    });
   }
 
   //this function is for worker job management
@@ -165,15 +163,12 @@ export const Cubes = ({
     }
   }
 
-  //attempt to give workers a job priority -- unfinished
   function jobTypePriority(type) {
     switch (type) {
       case "user":
         return 0;
       case "worldFill":
         return 1;
-      case "dyna":
-        return 3;
       default:
         return 0;
     }
@@ -181,7 +176,7 @@ export const Cubes = ({
 
   //function executed by workers asking for more work
   function getPendingJob(workernum) {
-    let job = workerPendingJob.current.shift();
+    const job = workerPendingJob.current.shift();
     if (job.type === "worldFill") {
       giveWorkerWorldFillJob(workernum, job.chunkinfo);
     } else if (job.type === "user") {
@@ -189,11 +184,88 @@ export const Cubes = ({
     }
   }
 
+  // Single entry point for every block mutation: local clicks, remote
+  // players, and persisted-edit replay all flow through here.
+  function applyBlockChange(event) {
+    recordEdit(event, !settings.onlineEnabled);
+
+    const ck = chunkKeyFromPosition(
+      event.pos[0],
+      event.pos[2],
+      worldSettings.chunkSize,
+    );
+    const chunk = chunks.current[ck];
+    if (!chunk) {
+      // chunk not generated yet -- the edit overlay applies it at gen time
+      return;
+    }
+
+    const key = makeKey(...event.pos);
+    if (event.type === "add") {
+      const existing = REF_ALLCUBES.current[key];
+      if (existing && existing.texture !== "water") {
+        return;
+      }
+      REF_ALLCUBES.current[key] = { pos: event.pos, texture: event.texture };
+      if (!existing) {
+        chunk.keys.push(key);
+        chunk.count++;
+      }
+    } else if (event.type === "remove") {
+      if (!(key in REF_ALLCUBES.current)) {
+        return;
+      }
+      delete REF_ALLCUBES.current[key];
+      const i = chunk.keys.indexOf(key);
+      if (i !== -1) {
+        chunk.keys[i] = chunk.keys[chunk.keys.length - 1];
+        chunk.keys.pop();
+      }
+      chunk.count--;
+    }
+    addWorkerJob(ck, "user");
+
+    // a block on a chunk border changes face culling in the neighbor too
+    const [x, , z] = event.pos;
+    const cS = worldSettings.chunkSize;
+    const neighbors = new Set();
+    [
+      [x - 1, z],
+      [x + 1, z],
+      [x, z - 1],
+      [x, z + 1],
+    ].forEach(([nx, nz]) => {
+      const nck = chunkKeyFromPosition(nx, nz, cS);
+      if (nck !== ck && chunks.current[nck]) {
+        neighbors.add(nck);
+      }
+    });
+    neighbors.forEach((nck) => addWorkerJob(nck, "user"));
+  }
+
+  function fillMissingChunks(centerChunk, radius) {
+    const missing = getNearbyChunkKeys(centerChunk, radius).filter((ck) => {
+      return !chunks.current[ck] && !pendingFill.current.has(ck);
+    });
+    if (!missing.length) {
+      return 0;
+    }
+    missing.sort(
+      (a, b) =>
+        distBetweenChunks(centerChunk, a) - distBetweenChunks(centerChunk, b),
+    );
+    missing.forEach((ck) => pendingFill.current.add(ck));
+    for (let i = 0; i < missing.length; i += fillBatchSize) {
+      addWorkerJob({ arr: missing.slice(i, i + fillBatchSize) }, "worldFill");
+    }
+    return missing.length;
+  }
+
   useFrame(() => {
-    const pChunk = chunkIdFromPosition(
+    const pChunk = chunkKeyFromPosition(
       camera.position.x,
       camera.position.z,
-      worldSettings,
+      worldSettings.chunkSize,
     );
 
     if (
@@ -203,14 +275,11 @@ export const Cubes = ({
     ) {
       playerChunkPosition.current = pChunk;
       if (
-        distBetweenChunks(
-          lastRenderChunk.current,
-          pChunk,
-          worldSettings.worldSize,
-        ) >=
+        distBetweenChunks(lastRenderChunk.current, pChunk) >=
         renderDistPrecentage * (outerViewRadius - viewRadius)
       ) {
-        checkWorldFilledRadius(pChunk);
+        lastRenderChunk.current = pChunk;
+        fillMissingChunks(pChunk, outerViewRadius);
       }
       updateDisplayedChunks(pChunk);
     }
@@ -218,6 +287,13 @@ export const Cubes = ({
 
   useEffect(() => {
     if (!workerList.current[0]) {
+      if (!settings.onlineEnabled) {
+        const loaded = loadEdits(worldSettings.seed);
+        if (loaded) {
+          console.log(`Loaded ${loaded} saved block edits`);
+        }
+      }
+
       let workersmade = 0;
       workerList.current.forEach((ele, ind) => {
         workerList.current[ind] = buildWorker(ind);
@@ -228,119 +304,46 @@ export const Cubes = ({
       });
       updateInitStatus({ buildWorkers: workersmade });
     }
-    // triggering world fill once
+    // initial world fill around spawn
     if (workerList.current[0] && !chunksMadeCounter.current.loaddone) {
-      const ourCurrentChunk = settings.startingChunk;
-      // fill closest chunks first so the area around the player loads first
-      const worldFillarr = getNearbyChunkIds(
-        ourCurrentChunk,
-        outerViewRadius,
-        worldSettings.worldSize,
-      ).sort(
-        (a, b) =>
-          distBetweenChunks(ourCurrentChunk, a, worldSettings.worldSize) -
-          distBetweenChunks(ourCurrentChunk, b, worldSettings.worldSize),
-      );
-      queueWorldFillBatches(worldFillarr);
+      const queued = fillMissingChunks(spawnChunk, outerViewRadius);
+      chunksMadeCounter.current.track.max = queued;
     }
+
+    setRemoteBlockApplier(applyBlockChange);
+    return () => setRemoteBlockApplier(null);
   }, []);
 
-  function queueWorldFillBatches(chunkIds) {
-    for (let i = 0; i < chunkIds.length; i += fillBatchSize) {
-      addWorkerJob({ arr: chunkIds.slice(i, i + fillBatchSize) }, "worldFill");
-    }
-  }
-
-  // apply block changes made by other online players
-  useEffect(() => {
-    if (!FillerLoadDoneValue) {
-      return;
-    }
-    setRemoteBlockApplier((event) => {
-      const [x, , z] = event.pos;
-      const cn = chunkIdFromPosition(x, z, worldSettings);
-      const chunk = chunks.current[cn];
-      if (cn < 0 || cn >= chunks.current.length || !chunk || !chunk.keys) {
-        return;
-      }
-
-      const key = makeKey(...event.pos);
-      if (event.type === "add") {
-        if (key in REF_ALLCUBES.current) {
-          return;
-        }
-        REF_ALLCUBES.current[key] = {
-          pos: event.pos,
-          texture: event.texture || "dirt",
-        };
-        chunk.keys.push(key);
-        chunk.count++;
-      } else if (event.type === "remove") {
-        if (!(key in REF_ALLCUBES.current)) {
-          return;
-        }
-        delete REF_ALLCUBES.current[key];
-        const i = chunk.keys.indexOf(key);
-        if (i !== -1) {
-          chunk.keys[i] = chunk.keys[chunk.keys.length - 1];
-          chunk.keys.pop();
-        }
-        chunk.count--;
-      }
-      addWorkerJob(cn, "user");
-    });
-    return () => setRemoteBlockApplier(null);
-  }, [FillerLoadDoneValue]);
-
   function updateDisplayedChunks(currentChunk) {
-    let chunksToDisplay = getNearbyChunkIds(
-      currentChunk,
-      viewRadius,
-      worldSettings.worldSize,
-    );
-    let removeChunks = activeChunks.current.filter((id) => {
-      return !chunksToDisplay.includes(id);
+    const chunksToDisplay = getNearbyChunkKeys(currentChunk, viewRadius);
+    const removeChunks = activeChunks.current.filter((ck) => {
+      return !chunksToDisplay.includes(ck);
     });
-    let newlyDisplayChunks = chunksToDisplay.filter((id) => {
-      return !activeChunks.current.includes(id);
+    removeChunks.forEach((ck) => {
+      if (chunks.current[ck]) {
+        chunks.current[ck].visible = false;
+      }
     });
-    removeChunks.forEach((id) => {
-      chunks.current[id].visible = false;
-    });
-    newlyDisplayChunks.forEach((id) => {
-      chunks.current[id].visible = true;
+    chunksToDisplay.forEach((ck) => {
+      if (chunks.current[ck]) {
+        chunks.current[ck].visible = true;
+      }
     });
     activeChunks.current = chunksToDisplay;
   }
 
-  function checkWorldFilledRadius(currentChunk) {
-    lastRenderChunk.current = playerChunkPosition.current;
-    const chunksTofill = getNearbyChunkIds(
-      currentChunk,
-      outerViewRadius,
-      worldSettings.worldSize,
-    ).filter((cn) => {
-      return !chunks.current[cn].count;
-    });
-    queueWorldFillBatches(chunksTofill);
-  }
-
-  function showChunks() {
-    return !chunksMadeCounter.current.loaddone
-      ? ""
-      : chunks.current.map((ele, ind) => {
-          return (
-            <Chunk
-              key={`cubechunk${ind}`}
-              chunkNum={ind}
-              chunkProps={chunks}
-              activeTextureREF={activeTextureREF}
-              REF_ALLCUBES={REF_ALLCUBES}
-              addWorkerJob={addWorkerJob}
-            />
-          );
-        });
-  }
-
-  return showChunks();
+  return !FillerLoadDoneValue
+    ? null
+    : chunkKeyList.map((ck) => {
+        return (
+          <Chunk
+            key={`cubechunk${ck}`}
+            chunkKey={ck}
+            chunkProps={chunks}
+            activeTextureREF={activeTextureREF}
+            REF_ALLCUBES={REF_ALLCUBES}
+            applyBlockChange={applyBlockChange}
+          />
+        );
+      });
 };

--- a/src/components/cubeComponents/DrawCubesGeo.jsx
+++ b/src/components/cubeComponents/DrawCubesGeo.jsx
@@ -1,29 +1,62 @@
 import { allMincraftTexture } from "../../images/textures";
 
+function BufferAttributes({ set }) {
+  return (
+    <bufferGeometry>
+      <bufferAttribute
+        attach="attributes-position"
+        array={set.vertices}
+        count={set.vertices.length / 3}
+        itemSize={3}
+      />
+      <bufferAttribute
+        attach="attributes-uv"
+        array={set.uvs}
+        count={set.uvs.length / 2}
+        itemSize={2}
+      />
+      <bufferAttribute
+        attach="attributes-normal"
+        array={set.normals}
+        count={set.normals.length / 3}
+        itemSize={3}
+      />
+      <bufferAttribute
+        attach="attributes-color"
+        array={set.colors}
+        count={set.colors.length / 3}
+        itemSize={3}
+      />
+    </bufferGeometry>
+  );
+}
+
 export const DrawCubesGeo = ({ info, clickCubeFace }) => {
   return (
-    <mesh onPointerDown={clickCubeFace} name="cubesMesh2">
-      <bufferGeometry>
-        <bufferAttribute
-          attach="attributes-position"
-          array={info.vertices}
-          count={info.vertices.length / 3}
-          itemSize={3}
-        />
-        <bufferAttribute
-          attach="attributes-uv"
-          array={info.uvs}
-          count={info.uvs.length / 2}
-          itemSize={2}
-        />
-        <bufferAttribute
-          attach="attributes-normal"
-          array={info.normals}
-          count={info.normals.length / 3}
-          itemSize={3}
-        />
-      </bufferGeometry>
-      <meshStandardMaterial attach="material" map={allMincraftTexture} />
-    </mesh>
+    <>
+      {info.solid.vertices.length > 0 && (
+        <mesh onPointerDown={clickCubeFace} name="cubesMesh2">
+          <BufferAttributes set={info.solid} />
+          <meshStandardMaterial
+            attach="material"
+            map={allMincraftTexture}
+            vertexColors
+          />
+        </mesh>
+      )}
+      {info.trans.vertices.length > 0 && (
+        <mesh name="cubesMeshWater">
+          <BufferAttributes set={info.trans} />
+          <meshStandardMaterial
+            attach="material"
+            color="#3f76e4"
+            transparent
+            opacity={0.65}
+            depthWrite={false}
+            vertexColors
+          />
+        </mesh>
+      )}
+    </>
   );
 };

--- a/src/components/cubeComponents/FormCubeArrays.jsx
+++ b/src/components/cubeComponents/FormCubeArrays.jsx
@@ -1,26 +1,16 @@
 import { DrawCubesGeo } from "./DrawCubesGeo";
 
-export const FormCubeArrays = ({chunkNum, clickCubeFace, chunkProps }) => {
-
-  function handledata(){
-    if(chunkProps.draw){
-      if(chunkProps.draw.vertices){
-        if(chunkProps.draw.vertices.length>0){
-          return (
-            [chunkProps.draw].map((inst) => {
-              return <DrawCubesGeo info={inst} key={`ACmesh${chunkProps.draw.cc}-${chunkNum}`} clickCubeFace={clickCubeFace} />
-            })
-          )
-        }
-      }
-    }
-
-    return <></>
-
-
+export const FormCubeArrays = ({ chunkKey, clickCubeFace, chunkProps }) => {
+  const draw = chunkProps.draw;
+  if (!draw || !draw.solid) {
+    return null;
   }
 
-  return(
-    handledata()
-  )
+  return (
+    <DrawCubesGeo
+      info={draw}
+      key={`ACmesh${draw.cc || 0}-${chunkKey}`}
+      clickCubeFace={clickCubeFace}
+    />
+  );
 };

--- a/src/components/playerComponents/BasicPlayer.js
+++ b/src/components/playerComponents/BasicPlayer.js
@@ -1,9 +1,88 @@
-// Simple visible body used to render other online players.
-export const Basicplayer = ({ mypos }) => {
+import { useRef, useEffect } from "react";
+import { useFrame } from "@react-three/fiber";
+import { Billboard, Text } from "@react-three/drei";
+import * as THREE from "three";
+
+// Remote player with smooth interpolation, blocky body, and name tag.
+export const RemotePlayer = ({ mypos, name }) => {
+  const groupRef = useRef();
+  const targetPosRef = useRef(new THREE.Vector3(...mypos));
+  const lerping = useRef(new THREE.Vector3(...mypos));
+
+  // Initialize group position to first mypos so players don't fly in from origin.
+  useEffect(() => {
+    if (groupRef.current) {
+      groupRef.current.position.copy(targetPosRef.current);
+      lerping.current.copy(targetPosRef.current);
+    }
+  }, []);
+
+  // Update target position when mypos prop changes.
+  useEffect(() => {
+    targetPosRef.current.set(mypos[0], mypos[1], mypos[2]);
+  }, [mypos[0], mypos[1], mypos[2]]);
+
+  // Smooth interpolation in useFrame.
+  useFrame((_, delta) => {
+    if (groupRef.current) {
+      const k = 1 - Math.pow(0.0001, delta);
+      groupRef.current.position.lerp(targetPosRef.current, k);
+    }
+  });
+
   return (
-    <mesh position={mypos}>
-      <sphereGeometry attach="geometry" args={[1]} />
-      <meshStandardMaterial attach="material" color="red" />
-    </mesh>
+    <group ref={groupRef} position={lerping.current}>
+      {/* Head: 0.5×0.5×0.5 at y=0 (eye level) */}
+      <mesh position={[0, 0, 0]}>
+        <boxGeometry attach="geometry" args={[0.5, 0.5, 0.5]} />
+        <meshStandardMaterial attach="material" color="#d8a878" />
+      </mesh>
+
+      {/* Torso: 0.5 wide × 0.7 tall × 0.28 deep at y≈-0.6 */}
+      <mesh position={[0, -0.6, 0]}>
+        <boxGeometry attach="geometry" args={[0.5, 0.7, 0.28]} />
+        <meshStandardMaterial attach="material" color="#00a8a8" />
+      </mesh>
+
+      {/* Left arm: 0.18×0.7×0.18 at x=-0.36, y≈-0.6 */}
+      <mesh position={[-0.36, -0.6, 0]}>
+        <boxGeometry attach="geometry" args={[0.18, 0.7, 0.18]} />
+        <meshStandardMaterial attach="material" color="#d8a878" />
+      </mesh>
+
+      {/* Right arm: 0.18×0.7×0.18 at x=0.36, y≈-0.6 */}
+      <mesh position={[0.36, -0.6, 0]}>
+        <boxGeometry attach="geometry" args={[0.18, 0.7, 0.18]} />
+        <meshStandardMaterial attach="material" color="#d8a878" />
+      </mesh>
+
+      {/* Left leg: 0.22×0.7×0.22 at x=-0.13, y≈-1.3 */}
+      <mesh position={[-0.13, -1.3, 0]}>
+        <boxGeometry attach="geometry" args={[0.22, 0.7, 0.22]} />
+        <meshStandardMaterial attach="material" color="#3838a8" />
+      </mesh>
+
+      {/* Right leg: 0.22×0.7×0.22 at x=0.13, y≈-1.3 */}
+      <mesh position={[0.13, -1.3, 0]}>
+        <boxGeometry attach="geometry" args={[0.22, 0.7, 0.22]} />
+        <meshStandardMaterial attach="material" color="#3838a8" />
+      </mesh>
+
+      {/* Name tag: floating above head, always facing camera */}
+      <Billboard position={[0, 0.55, 0]}>
+        <Text
+          fontSize={0.25}
+          color="white"
+          outlineWidth={0.02}
+          outlineColor="black"
+          anchorY="bottom"
+        >
+          {name}
+        </Text>
+      </Billboard>
+    </group>
   );
 };
+
+// Alias export for backwards compatibility.
+export const Basicplayer = RemotePlayer;

--- a/src/components/playerComponents/OtherPlayers.js
+++ b/src/components/playerComponents/OtherPlayers.js
@@ -7,7 +7,22 @@ export const OtherPlayers = () => {
   return (
     <>
       {Object.keys(players).map((pn) => {
-        return <Basicplayer mypos={players[pn].pos} key={`player${pn}`} />;
+        const player = players[pn];
+        // Filter out players whose pos is [-10,-10,-10] (not-yet-spawned placeholder).
+        if (
+          player.pos[0] === -10 &&
+          player.pos[1] === -10 &&
+          player.pos[2] === -10
+        ) {
+          return null;
+        }
+        return (
+          <Basicplayer
+            mypos={player.pos}
+            name={player.name || `Player ${pn}`}
+            key={pn}
+          />
+        );
       })}
     </>
   );

--- a/src/components/playerComponents/Player.js
+++ b/src/components/playerComponents/Player.js
@@ -45,7 +45,7 @@ export const Player = ({ moveBools, playerStartingPostion, REF_ALLCUBES }) => {
     floor: {
       solid: [], // default to solid
       liquid: ["water"],
-      air: [],
+      air: ["water"], // non-solid for collision purposes
     },
   };
 
@@ -113,31 +113,17 @@ export const Player = ({ moveBools, playerStartingPostion, REF_ALLCUBES }) => {
     doSightWithJoy();
   }
 
-  //stop player from moving outside world boundries
-  function checkAbsoluteMapLimits([x, y, z]) {
-    let worldSideLen =
-      settings.worldSettings.chunkSize * settings.worldSettings.worldSize;
-
-    if (pos.current[0] <= 0.1) {
-      x = 1;
-    }
-    if (pos.current[0] >= worldSideLen - 0.9) {
-      x = -1;
-    }
-    if (pos.current[1] <= 0.1) {
-      y = 1;
-    }
-    if (pos.current[2] <= 0.1) {
-      z = 1;
-    }
-    if (pos.current[2] >= worldSideLen - 0.9) {
-      z = -1;
-    }
-    return [x, y, z];
+  function isInWater() {
+    const [x, y, z] = pos.current.map(Math.round);
+    const feet = REF_ALLCUBES.current[makeKey(x, y - 1, z)];
+    const eyes = REF_ALLCUBES.current[makeKey(x, y, z)];
+    return feet?.texture === "water" || eyes?.texture === "water";
   }
 
   function worldPhysicsController(direction, surrData, dt) {
     let [vel_x, vel_y, vel_z] = [direction.x, direction.y, direction.z];
+    const inWater = isInWater();
+    movementStatus.current.inWater = inWater;
 
     if (!movementStatus.current.flying) {
       //check vertical limits
@@ -147,6 +133,14 @@ export const Player = ({ moveBools, playerStartingPostion, REF_ALLCUBES }) => {
 
       if (!movementStatus.current.onGround) {
         vel_y += GRAVITY * dt;
+        // water: sink slowly, swim up with jump
+        if (inWater) {
+          const maxSink = -2;
+          vel_y = vel_y < maxSink ? maxSink : vel_y;
+          if (jump.on || moveBools.current.jump) {
+            vel_y = 3;
+          }
+        }
         vel_y = vel_y <= MAXfallspeed ? MAXfallspeed : vel_y;
 
         //check bottom
@@ -257,7 +251,7 @@ export const Player = ({ moveBools, playerStartingPostion, REF_ALLCUBES }) => {
       vel_z = velArr[2];
     }
 
-    return checkAbsoluteMapLimits([vel_x, vel_y, vel_z]);
+    return [vel_x, vel_y, vel_z];
   }
 
   function checkTerrain() {
@@ -403,6 +397,12 @@ export const Player = ({ moveBools, playerStartingPostion, REF_ALLCUBES }) => {
     pos.current[1] += vel.current[1] * dt;
     pos.current[2] += vel.current[2] * dt;
 
+    // fell out of the world (e.g. into an ungenerated chunk) -- respawn
+    if (pos.current[1] < settings.worldSettings.minY - 20) {
+      pos.current = [...playerStartingPostion];
+      vel.current = [0, 0, 0];
+    }
+
     // camera follows "player"
     if (!settings.ignoreCameraFollowPlayer) {
       camera.position.set(...pos.current);
@@ -414,6 +414,11 @@ export const Player = ({ moveBools, playerStartingPostion, REF_ALLCUBES }) => {
       window.__playerPos = [...pos.current];
       window.__camDir = camera.getWorldDirection(new Vector3()).toArray();
       window.__camera = camera;
+      window.__teleport = (x, y, z) => {
+        pos.current = [x, y, z];
+        vel.current = [0, 0, 0];
+      };
+      window.__blocks = REF_ALLCUBES.current;
     }
   });
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,13 +1,12 @@
-import { chunkIdFromPosition } from "./world/chunkMath";
-
-// Game configuration. Mostly static, but a few fields are set at runtime:
-// - movewithJOY_BOOL comes from the title screen choice
-// - startingChunk is recalculated when the start position is randomized
+// Game configuration. Mostly static, but a few fields are set at runtime
+// from the title screen: movewithJOY_BOOL, onlineEnabled, playerName, and
+// worldSettings.seed.
 const settings = {
-  // tries localhost:5000 (or the remote server); falls back to offline if unreachable
-  onlineEnabled: true,
+  // tries the multiplayer server; falls back to offline if unreachable
+  onlineEnabled: false,
   // when online, connect to the deployed ReactMineCraftCloneServer instead of localhost
   useRemoteServer: false,
+  playerName: "Player",
 
   showPlayer: true,
   showOtherPlayers: true,
@@ -17,38 +16,26 @@ const settings = {
   showCubes: true,
 
   viewRadius: 6, //distance (in chunks) from current chunk that chunks are shown
-  outerViewRadius: 8, //distance (in chunks) we ensure are built/ready to be shown
+  outerViewRadius: 8, //distance (in chunks) we insure are built/ready to be shown
   renderDistPrecentage: 50 / 100,
   fillBatchSize: 10,
   workerCount: 3,
 
-  showLoadingWorldBanner: false,
+  showLoadingWorldBanner: true,
 
-  activeTexture: "AllMinecraftTexture",
-
-  randomizeStartPos: false,
   startingPositionDefault: [2, 30, 2],
   startingRotationDefault: [-45, 220, 0].map((val) => {
     return (val * Math.PI) / 180;
   }),
-  startingChunk: -1, //gets calculated below
 
-  //world set up configs
+  //world set up configs -- the world is infinite; chunks generate on demand
   worldSettings: {
-    useHeightTextures: false,
-    showFlatWorld: false,
     seed: "robo",
-    worldSize: 16, //this squared is the number of chunks in the world
-    chunkSize: 8, //this squared is the number of blocks in each chunk
-    heightFactor: 10, //how high up noise can make hills
-    depth: 0, // how far down blocks are stacked
+    chunkSize: 8, //this squared is the number of block columns in each chunk
+    heightFactor: 12, //how high up noise can make hills
+    waterLevel: 0, //columns below this height fill with water
+    minY: -7, //bedrock floor
   },
 };
-
-settings.startingChunk = chunkIdFromPosition(
-  settings.startingPositionDefault[0],
-  settings.startingPositionDefault[2],
-  settings.worldSettings,
-);
 
 export default settings;

--- a/src/hooks/useOnlineConnection.js
+++ b/src/hooks/useOnlineConnection.js
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import settings from "../constants";
 import { useStore } from "./useStore";
 import { applyRemoteBlockEvent } from "../world/remoteBlocks";
+import { clearEdits } from "../world/edits";
 import io from "socket.io-client";
 
 // Server code lives at https://github.com/GreyDaCaLa/ReactMineCraftCloneServer
@@ -31,13 +32,16 @@ function connectSocket() {
   });
 
   sharedSocket.on("S_GiveWorld", (world) => {
-    // replay every block other players placed before we joined
+    // replay every block edit made before we joined
     (world.cubes || []).forEach((cube) => {
       applyRemoteBlockEvent({
         type: "add",
         pos: cube.pos,
         texture: cube.texture,
       });
+    });
+    (world.removed || []).forEach((pos) => {
+      applyRemoteBlockEvent({ type: "remove", pos });
     });
     store.online_setPlayersPos(world.players);
     store.online_SetEstablishedConn(true);
@@ -55,6 +59,7 @@ function connectSocket() {
     applyRemoteBlockEvent({ type: "remove", pos });
   });
   sharedSocket.on("S_BlocksReset", () => {
+    clearEdits();
     window.location.reload();
   });
 
@@ -73,19 +78,23 @@ function connectSocket() {
 }
 
 // Opens the socket.io connection and keeps player/world state in the store.
+// `start` is false until the player picks a game mode on the title screen.
 // When online play is disabled this just marks the connection as established
 // so the game can proceed.
-export function useOnlineConnection() {
+export function useOnlineConnection(start) {
   const establishedConn = useStore((state) => state.establishedConn);
 
   useEffect(() => {
+    if (!start) {
+      return;
+    }
     if (settings.onlineEnabled) {
       connectSocket();
     } else if (!useStore.getState().establishedConn) {
       useStore.getState().online_SetEstablishedConn(true);
     }
     // the server removes our player on disconnect, so no unmount cleanup needed
-  }, []);
+  }, [start]);
 
   return establishedConn;
 }

--- a/src/hooks/useOnlineConnection.js
+++ b/src/hooks/useOnlineConnection.js
@@ -48,6 +48,10 @@ function connectSocket() {
   });
   sharedSocket.on("S_GiveplayerNum", (pnum) => {
     store.online_setplayerNum(pnum);
+    sharedSocket.emit("C_SetName", {
+      worldname: null,
+      name: settings.playerName,
+    });
   });
   sharedSocket.on("S_HeartBeat", (world) => {
     useStore.getState().online_setPlayersPos(world.players);

--- a/src/index.css
+++ b/src/index.css
@@ -23,25 +23,16 @@ body {
   position: fixed;
   overflow: hidden;
   overscroll-behavior-y: none;
-  font-family: -apple-system, BlinkMacSystemFont, avenir next, avenir, helvetica neue, helvetica, ubuntu, roboto, noto, segoe ui, arial, sans-serif;
-  font-size: 40px;
+  font-family: "Courier New", Courier, monospace;
+  font-size: 16px;
 }
 
-.flex {
-  display: flex;
-}
+/* ── layout helpers ─────────────────────────────────────────────── */
 
-.fixed {
-  position: fixed;
-}
-
-.relative {
-  position: relative;
-}
-
-.absolute {
-  position: absolute;
-}
+.flex    { display: flex; }
+.fixed   { position: fixed; }
+.relative { position: relative; }
+.absolute { position: absolute; }
 
 .centered {
   top: 50%;
@@ -55,158 +46,90 @@ body {
   transform: translate(-50%, -50%);
 }
 
+/* ── crosshair cursor ───────────────────────────────────────────── */
+
 .cursor {
   color: white;
+  font-size: 28px;
+  font-weight: bold;
+  line-height: 1;
+  text-shadow: 0 0 2px #000, 1px 1px 0 #000;
+  pointer-events: none;
+  z-index: 10;
 }
 
-.texture-selector {
-  transform: scale(5);
-}
+/* ── existing misc ──────────────────────────────────────────────── */
 
-.texture-selector img.active {
-  border: 2px solid red;
-}
+.menu  { top: 0px; left: 10px; }
+.help  { top: 0px; right: 10px; font-size: medium; color: white; }
 
-.menu {
-  top: 0px;
-  left: 10px;
-}
+.joystick { border: red 1px solid; }
 
-.help {
-  top: 0px;
-  right: 10px;
-  font-size: medium;
-  color: white;
-}
-
-
-#loadingpage{
-  background-color: red;
-}
-
-
-#LowerControlStrip{
+#LowerControlStrip {
   background-color: green;
-  position:absolute;
+  position: absolute;
   z-index: 10;
   width: 100vw;
-  height: min(2,50vh);
+  height: min(2, 50vh);
   bottom: 0px;
   display: flex;
   justify-content: space-between;
-  /* align-self:flex-end; */
 }
 
-.joystick{
-  border: red 1px solid;
-}
-
-@import url('https://fonts.googleapis.com/css?family=Press+Start+2P');
-@import url('https://fonts.googleapis.com/css2?family=Rubik+Iso&family=Wallpoet&display=swap');
+/* ── Minecraft text classes (kept for backward compat) ──────────── */
 
 .minecraft-text {
-  font-family: 'Press Start 2P', cursive;
-  font-size: 24px; /* Adjust the size as needed */
-  color: #00ff00; /* Set your desired color */
-  stroke: #00ff00;
-}
-.minecraft-text2 {
-  font-family: 'Rubik Iso', cursive;
-  color: black; /* Set your desired color */
-  stroke: black;
-}
-.minecraft-text3 {
-  font-family: 'Wallpoet', cursive;
-  /* font-size: 80px;  */
-  color: black;
-  stroke: black;
-  stroke-width: .5px;
-  /* background-color: #00ff00; */
+  font-family: "Courier New", Courier, monospace;
+  font-size: 24px;
+  font-weight: bold;
+  letter-spacing: 2px;
+  color: #00ff00;
 }
 
+.minecraft-text2 {
+  font-family: "Courier New", Courier, monospace;
+  font-weight: bold;
+  color: black;
+}
+
+.minecraft-text3 {
+  font-family: "Courier New", Courier, monospace;
+  font-weight: bold;
+  letter-spacing: 1px;
+  color: black;
+}
+
+/* ── legacy card/container (kept for backward compat) ──────────── */
 
 .card {
-    box-shadow: 0 4px 8px 0 rgba(0,0,0,0.2);
-    transition: 0.3s;
-    width: 40vw;
-    height: 80vh;
-  }
-  
-
-  .card:hover {
-    box-shadow: 16px 16px 16px 16px rgba(0,0,0,0.6);
-  }
-  
-
-  .container {
-    padding: 2px 16px;
-    height: 100%;
-    background-color: red;
-  }
-
-  .pageContainer{
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    height: 100vh;
-    width: 100vw;
-    position:absolute;
-    top: 0;
-    left:0;
-  }
-
-
-
-
-.input-group > * {
-  font-size: small;
+  box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2);
+  transition: 0.3s;
+  width: 40vw;
+  height: 80vh;
 }
 
-  input,
-  textarea {
-    /* font-size: small; */
-  }
-  
-  .input-group {
-    display: table;
-    border-collapse: collapse;
-    width: 100%;
-    height: 10px;
-  }
-  
-  .input-group > * {
-    display: table-cell;
-    /* border: 1px solid black; */
-    vertical-align: middle;
-  }
-  
-  div.input-group> label{
-    border-radius: 10px 0px 0px 10px;
-  }
-  div.input-group-area> input{
-    border-radius: 0px 10px 10px 0px;
-  }
-  
-  .input-group-icon {
-    background-color: #eee;
-    color: #777;
-    padding: 5px 5px;
-  }
-  
-  .input-group-area {
-    width: 100%;
-  }
-  
-  .input-group input {
-    border: 0;
-    display: block;
-    width: 100%;
-    height: 100%;
-    padding: 0px;
-  }
+.card:hover {
+  box-shadow: 16px 16px 16px 16px rgba(0, 0, 0, 0.6);
+}
 
+.container {
+  padding: 2px 16px;
+  height: 100%;
+  background-color: red;
+}
 
-.TitleCard_Container{
+.pageContainer {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  width: 100vw;
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+
+.TitleCard_Container {
   background-color: black;
   height: 100%;
   width: 100%;
@@ -215,13 +138,511 @@ body {
   align-items: center;
 }
 
-.TitleCard_ColorBlock{
-  width: min(80%,100vh);
+.TitleCard_ColorBlock { width: min(80%, 100vh); }
+.TitleCard_Heading {}
+.TitleCard_SubHeading {}
+.TitleCard_Button {}
+.TitleCard_Form {}
+.TitleCard_FormButton {}
+
+/* ── Minecraft-style shared button ─────────────────────────────── */
+
+.mc-play-btn {
+  display: block;
+  width: 100%;
+  padding: 12px 8px;
+  margin-top: 10px;
+  font-family: "Courier New", Courier, monospace;
+  font-size: 14px;
+  font-weight: bold;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  color: #fff;
+  text-shadow: 2px 2px 0 #333;
+  background: linear-gradient(to bottom, #8b8b8b 0%, #6b6b6b 49%, #5a5a5a 50%, #6b6b6b 100%);
+  border: none;
+  border-top: 2px solid #c8c8c8;
+  border-left: 2px solid #c8c8c8;
+  border-right: 2px solid #373737;
+  border-bottom: 2px solid #373737;
+  cursor: pointer;
+  outline: none;
+  transition: filter 0.05s ease;
+  user-select: none;
 }
 
-.TitleCard_Heading{}
-.TitleCard_SubHeading{}
-.TitleCard_Button{}
-.TitleCard_Form{}
-.TitleCard_FormButton{}
+.mc-play-btn:hover {
+  filter: brightness(1.25);
+}
 
+.mc-play-btn:active {
+  border-top: 2px solid #373737;
+  border-left: 2px solid #373737;
+  border-right: 2px solid #c8c8c8;
+  border-bottom: 2px solid #c8c8c8;
+  filter: brightness(0.9);
+}
+
+.mc-play-btn--danger {
+  background: linear-gradient(to bottom, #8b4040 0%, #6b2a2a 49%, #5a1f1f 50%, #6b2a2a 100%);
+  border-top-color: #c87070;
+  border-left-color: #c87070;
+}
+
+/* ── Title Screen ───────────────────────────────────────────────── */
+
+.title-screen {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  z-index: 100;
+}
+
+.title-screen__bg {
+  position: absolute;
+  inset: 0;
+  background-repeat: repeat;
+  background-size: 64px 64px;
+  image-rendering: pixelated;
+  image-rendering: crisp-edges;
+}
+
+.title-screen__overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.62);
+}
+
+.title-screen__content {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: min(480px, 92vw);
+}
+
+.title-screen__logo {
+  font-family: "Courier New", Courier, monospace;
+  font-size: clamp(32px, 9vw, 72px);
+  font-weight: bold;
+  letter-spacing: 4px;
+  text-transform: uppercase;
+  color: #fff;
+  text-shadow:
+    4px 4px 0 #3a3a3a,
+    -2px -2px 0 #555,
+    6px 6px 0 #000,
+    0 0 20px rgba(100, 220, 80, 0.5);
+  margin: 0 0 28px 0;
+  text-align: center;
+}
+
+.title-screen__panel {
+  background: rgba(0, 0, 0, 0.72);
+  border: 3px solid #555;
+  border-bottom-color: #222;
+  border-right-color: #222;
+  border-top-color: #888;
+  border-left-color: #888;
+  padding: 24px 28px 20px;
+  width: 100%;
+}
+
+.mc-field {
+  margin-bottom: 14px;
+}
+
+.mc-label {
+  display: block;
+  font-family: "Courier New", Courier, monospace;
+  font-size: 11px;
+  font-weight: bold;
+  letter-spacing: 1px;
+  color: #ccc;
+  text-shadow: 1px 1px 0 #000;
+  margin-bottom: 5px;
+  text-transform: uppercase;
+}
+
+.mc-input {
+  display: block;
+  width: 100%;
+  padding: 10px 10px;
+  font-family: "Courier New", Courier, monospace;
+  font-size: 13px;
+  font-weight: bold;
+  color: #fff;
+  background: #1a1a1a;
+  border: 2px solid #555;
+  border-top-color: #222;
+  border-left-color: #222;
+  border-bottom-color: #888;
+  border-right-color: #888;
+  outline: none;
+  letter-spacing: 1px;
+}
+
+.mc-input:focus {
+  border-color: #7ec850;
+  background: #1e2a1a;
+}
+
+.mc-mode-row {
+  display: flex;
+  gap: 8px;
+}
+
+.mc-mode-btn {
+  flex: 1;
+  padding: 10px 4px;
+  font-family: "Courier New", Courier, monospace;
+  font-size: 11px;
+  font-weight: bold;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  color: #ccc;
+  text-shadow: 1px 1px 0 #000;
+  background: linear-gradient(to bottom, #6b6b6b 0%, #4a4a4a 49%, #3a3a3a 50%, #4a4a4a 100%);
+  border: none;
+  border-top: 2px solid #999;
+  border-left: 2px solid #999;
+  border-right: 2px solid #222;
+  border-bottom: 2px solid #222;
+  cursor: pointer;
+  outline: none;
+  transition: filter 0.05s ease;
+}
+
+.mc-mode-btn:hover {
+  filter: brightness(1.2);
+}
+
+.mc-mode-btn--active {
+  color: #fff;
+  text-shadow: 1px 1px 0 #000, 0 0 8px #7ec850;
+  background: linear-gradient(to bottom, #5a7a3a 0%, #3d5c28 49%, #2e4a1c 50%, #3d5c28 100%);
+  border-top-color: #8dc860;
+  border-left-color: #8dc860;
+}
+
+.title-screen__footer {
+  position: fixed;
+  bottom: 10px;
+  right: 14px;
+  z-index: 1;
+  font-family: "Courier New", Courier, monospace;
+  font-size: 10px;
+  letter-spacing: 1px;
+  color: rgba(200, 200, 200, 0.6);
+  text-shadow: 1px 1px 0 #000;
+}
+
+/* ── Connecting screen ──────────────────────────────────────────── */
+
+@keyframes pulse-opacity {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0.5; }
+}
+
+.connecting-screen {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-image: url("./images/dirt.jpg");
+  background-repeat: repeat;
+  background-size: 64px 64px;
+  image-rendering: pixelated;
+  image-rendering: crisp-edges;
+  z-index: 200;
+}
+
+.connecting-screen::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.65);
+}
+
+.connecting-screen::after {
+  content: "Connecting to server...";
+  position: relative;
+  z-index: 1;
+  font-family: "Courier New", Courier, monospace;
+  font-size: clamp(14px, 3vw, 22px);
+  font-weight: bold;
+  letter-spacing: 2px;
+  color: #fff;
+  text-shadow: 2px 2px 0 #000;
+  animation: pulse-opacity 1.4s ease-in-out infinite;
+}
+
+/* hide the original text node — we show it via ::after */
+.connecting-screen > * {
+  display: none;
+}
+
+/* ── Loading World Screen ───────────────────────────────────────── */
+
+@keyframes loading-fade-out {
+  from { opacity: 1; }
+  to   { opacity: 0; }
+}
+
+.loading-screen {
+  position: fixed;
+  inset: 0;
+  z-index: 90;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-repeat: repeat;
+  background-size: 64px 64px;
+  image-rendering: pixelated;
+  image-rendering: crisp-edges;
+}
+
+.loading-screen--fade {
+  animation: loading-fade-out 0.6s ease forwards;
+}
+
+.loading-screen__overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.7);
+}
+
+.loading-screen__content {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: min(400px, 88vw);
+}
+
+.loading-screen__title {
+  font-family: "Courier New", Courier, monospace;
+  font-size: clamp(18px, 5vw, 28px);
+  font-weight: bold;
+  letter-spacing: 3px;
+  text-transform: uppercase;
+  color: #fff;
+  text-shadow: 3px 3px 0 #000;
+  margin: 0 0 20px 0;
+}
+
+.loading-screen__bar-track {
+  width: 100%;
+  height: 28px;
+  background: #111;
+  border: 3px solid #555;
+  border-top-color: #222;
+  border-left-color: #222;
+  border-bottom-color: #888;
+  border-right-color: #888;
+  overflow: hidden;
+}
+
+.loading-screen__bar-fill {
+  height: 100%;
+  background: linear-gradient(to bottom, #7ec850 0%, #5aaa30 49%, #48921e 50%, #5aaa30 100%);
+  transition: width 0.2s ease;
+  min-width: 0;
+}
+
+.loading-screen__pct {
+  font-family: "Courier New", Courier, monospace;
+  font-size: 13px;
+  font-weight: bold;
+  letter-spacing: 1px;
+  color: #ccc;
+  margin-top: 8px;
+  text-shadow: 1px 1px 0 #000;
+}
+
+.loading-screen__workers {
+  font-family: "Courier New", Courier, monospace;
+  font-size: 11px;
+  color: #888;
+  margin-top: 6px;
+  letter-spacing: 1px;
+  text-shadow: 1px 1px 0 #000;
+}
+
+/* ── Hotbar ─────────────────────────────────────────────────────── */
+
+.hotbar {
+  position: fixed;
+  bottom: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: 4px;
+  z-index: 20;
+  padding: 4px;
+  background: rgba(0, 0, 0, 0.45);
+  border: 2px solid #555;
+  border-top-color: #888;
+  border-left-color: #888;
+  border-bottom-color: #222;
+  border-right-color: #222;
+}
+
+.hotbar__slot {
+  width: 48px;
+  height: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(20, 20, 20, 0.7);
+  border: 2px solid #444;
+  border-top-color: #222;
+  border-left-color: #222;
+  border-bottom-color: #666;
+  border-right-color: #666;
+  transition: transform 0.07s ease, border-color 0.07s ease;
+}
+
+.hotbar__slot--active {
+  border: 3px solid #fff;
+  box-shadow: inset 0 0 0 1px #aaa;
+  transform: scale(1.1);
+}
+
+.hotbar__img {
+  width: 38px;
+  height: 38px;
+  image-rendering: pixelated;
+  image-rendering: crisp-edges;
+  display: block;
+}
+
+/* ── Pause / Click-to-play Overlay ──────────────────────────────── */
+
+.pause-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 80;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.55);
+  cursor: pointer;
+}
+
+.pause-overlay__panel {
+  background: rgba(0, 0, 0, 0.82);
+  border: 3px solid #555;
+  border-top-color: #888;
+  border-left-color: #888;
+  border-bottom-color: #222;
+  border-right-color: #222;
+  padding: 28px 36px 24px;
+  width: min(420px, 90vw);
+  cursor: default;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.pause-overlay__title {
+  font-family: "Courier New", Courier, monospace;
+  font-size: clamp(16px, 4vw, 24px);
+  font-weight: bold;
+  letter-spacing: 3px;
+  text-transform: uppercase;
+  color: #fff;
+  text-shadow: 3px 3px 0 #000;
+  margin: 0 0 20px 0;
+  text-align: center;
+}
+
+.pause-overlay__controls {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 18px;
+}
+
+.pause-overlay__controls tr + tr td {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.pause-overlay__key {
+  font-family: "Courier New", Courier, monospace;
+  font-size: 11px;
+  font-weight: bold;
+  letter-spacing: 1px;
+  color: #f0c050;
+  text-shadow: 1px 1px 0 #000;
+  padding: 6px 10px 6px 0;
+  white-space: nowrap;
+}
+
+.pause-overlay__action {
+  font-family: "Courier New", Courier, monospace;
+  font-size: 11px;
+  letter-spacing: 1px;
+  color: #ccc;
+  text-shadow: 1px 1px 0 #000;
+  padding: 6px 0;
+}
+
+.pause-overlay__btn-row {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  width: 100%;
+}
+
+.pause-overlay__click-btn {
+  margin-top: 4px;
+}
+
+/* ── input / form legacy ────────────────────────────────────────── */
+
+.input-group > * { font-size: small; }
+
+input,
+textarea { }
+
+.input-group {
+  display: table;
+  border-collapse: collapse;
+  width: 100%;
+  height: 10px;
+}
+
+.input-group > * {
+  display: table-cell;
+  vertical-align: middle;
+}
+
+div.input-group > label         { border-radius: 10px 0px 0px 10px; }
+div.input-group-area > input    { border-radius: 0px 10px 10px 0px; }
+
+.input-group-icon {
+  background-color: #eee;
+  color: #777;
+  padding: 5px 5px;
+}
+
+.input-group-area { width: 100%; }
+
+.input-group input {
+  border: 0;
+  display: block;
+  width: 100%;
+  height: 100%;
+  padding: 0px;
+}
+
+/* ── legacy texture-selector (unused but kept to avoid breaking refs) */
+.texture-selector { transform: scale(5); }
+.texture-selector img.active { border: 2px solid red; }

--- a/src/workers/chunkWorker.js
+++ b/src/workers/chunkWorker.js
@@ -1,8 +1,8 @@
 import { createNoise2D } from "simplex-noise";
 import alea from "alea";
 import { makeKey } from "../world/keys";
-import { AMTmapkeys } from "../world/atlas";
-import { genFaceArrays } from "../world/meshGen";
+import { parseChunkKey } from "../world/chunkMath";
+import { genFaceArrays, packDrawArrays } from "../world/meshGen";
 
 let worldSet = {};
 
@@ -28,99 +28,128 @@ function initializeWorker(init) {
   postMessage({ init: true });
 }
 
-// Rebuilds a single chunk's mesh after a user placed or removed a block.
+// Rebuilds a single chunk's mesh after a block was placed or removed.
 function regularFlow(data) {
-  let { t, blocks, chunkBlocks, chunkNumber } = data;
+  const { t, blocks, chunkBlocks, chunkKey } = data;
 
-  let [vertices, uvs, normals] = genFaceArrays(t, blocks, chunkBlocks);
-  vertices = new Float32Array(vertices);
-  uvs = new Float32Array(uvs);
-  normals = new Float32Array(normals);
-  const singleChunkResponse = {
-    vertices,
-    uvs,
-    normals,
-    count: chunkBlocks.count,
-    chunkNumber,
-    blocksOfChunk: chunkBlocks,
-  };
-  postMessage({ regFlow: singleChunkResponse });
+  const draw = packDrawArrays(genFaceArrays(t, blocks, chunkBlocks));
+  postMessage({
+    regFlow: {
+      draw,
+      count: chunkBlocks.count,
+      chunkKey,
+    },
+  });
 }
 
-// Generates terrain blocks for a batch of chunks, then meshes them.
-function initialFill(chunkNumbers) {
+// Terrain column height from two octaves of seeded noise. Shifted down so
+// low areas dip below sea level and fill with water.
+function surfaceHeight(x, z) {
+  const noise2D = worldSet.genNoise2D;
+  const broad = (noise2D(x / 100, z / 100) + 1) / 2; // rolling hills
+  const detail = (noise2D(x / 25, z / 25) + 1) / 2; // small bumps
+  return Math.floor(broad * worldSet.heightFactor + detail * 3) - 3;
+}
+
+function columnBlocks(x, z, info, infoList) {
+  const h = surfaceHeight(x, z);
+  const { minY, waterLevel } = worldSet;
+  const beach = h <= waterLevel + 1;
+
+  for (let y = minY; y <= h; y++) {
+    let texture;
+    if (y === minY) {
+      texture = "bedrock";
+    } else if (y === h) {
+      texture = beach ? "sand" : "grass";
+    } else if (y >= h - 3) {
+      texture = beach ? "sand" : "dirt";
+    } else {
+      texture = "stone";
+    }
+    const key = makeKey(x, y, z);
+    infoList.push(key);
+    info[key] = { pos: [x, y, z], texture };
+  }
+
+  // fill up to sea level with water
+  for (let y = h + 1; y <= waterLevel; y++) {
+    const key = makeKey(x, y, z);
+    infoList.push(key);
+    info[key] = { pos: [x, y, z], texture: "water" };
+  }
+}
+
+// Generates terrain blocks for a batch of chunks, applies player edits,
+// then meshes them.
+function initialFill({ chunks, edits }) {
   const fillRes = {};
-  chunkNumbers.forEach((chunkNumber) => {
-    const cS = worldSet.chunkSize;
-    const wS = worldSet.worldSize;
-    const cnX = Math.floor(chunkNumber / wS);
-    const cnZ = chunkNumber % wS;
-    const noise2D = worldSet.genNoise2D;
+  const cS = worldSet.chunkSize;
+
+  chunks.forEach((ck) => {
+    const { cx, cz } = parseChunkKey(ck);
     const info = {};
     const infoList = [];
-    const ys = 1;
-    const heightFactor = worldSet.heightFactor;
-    const depth = worldSet.depth;
-    const difflimit = AMTmapkeys.length;
 
-    for (let x = cS * cnX; x < cS * cnX + cS; x++) {
-      for (let y = -1 * Math.abs(depth); y < ys; y++) {
-        for (let z = cS * cnZ; z < cS * cnZ + cS; z++) {
-          const ty = worldSet.showFlatWorld
-            ? y
-            : Math.floor(((noise2D(x / 100, z / 100) + 1) * heightFactor) / 2) +
-              y;
-
-          const key = makeKey(x, ty, z);
-          let texture = "";
-          if (worldSet.useHeightTextures) {
-            texture = AMTmapkeys[Math.abs(ty) % difflimit];
-          } else {
-            texture = Math.abs(x - z) < 16 ? "wood" : "grass";
-          }
-          infoList.push(key);
-          info[key] = {
-            pos: [x, ty, z],
-            texture,
-          };
-        }
+    for (let x = cS * cx; x < cS * cx + cS; x++) {
+      for (let z = cS * cz; z < cS * cz + cS; z++) {
+        columnBlocks(x, z, info, infoList);
       }
     }
-    fillRes[chunkNumber] = { info, infoList };
+
+    fillRes[ck] = { info, infoList };
   });
-  const [ac, testor] = initialRenders(fillRes, chunkNumbers);
-  postMessage({ worldFiller: { chunkNumbers, ac, testor } });
+
+  // overlay player edits (adds/removes recorded against generated terrain)
+  if (edits) {
+    const chunkSet = {};
+    chunks.forEach((ck) => {
+      chunkSet[ck] = fillRes[ck];
+    });
+    Object.entries(edits).forEach(([blockKey, event]) => {
+      const cx = Math.floor(event.pos[0] / cS);
+      const cz = Math.floor(event.pos[2] / cS);
+      const res = chunkSet[cx + "." + cz];
+      if (!res) {
+        return;
+      }
+      if (event.type === "add") {
+        if (!res.info[blockKey]) {
+          res.infoList.push(blockKey);
+        }
+        res.info[blockKey] = { pos: event.pos, texture: event.texture };
+      } else if (event.type === "remove" && res.info[blockKey]) {
+        delete res.info[blockKey];
+        res.infoList.splice(res.infoList.indexOf(blockKey), 1);
+      }
+    });
+  }
+
+  const [ac, testor] = initialRenders(fillRes, chunks);
+  postMessage({ worldFiller: { chunkKeys: chunks, ac, testor } });
 }
 
-function initialRenders(fillRes, chunkNumbers) {
+function initialRenders(fillRes, chunkKeys) {
   const t = 0.5;
 
-  let blocks = {};
-  chunkNumbers.forEach((cn) => {
-    Object.assign(blocks, fillRes[cn].info);
+  const blocks = {};
+  chunkKeys.forEach((ck) => {
+    Object.assign(blocks, fillRes[ck].info);
   });
 
-  chunkNumbers.forEach((cn) => {
+  chunkKeys.forEach((ck) => {
     const chunkBlocks = {
-      keys: fillRes[cn].infoList,
-      count: fillRes[cn].infoList.length,
+      keys: fillRes[ck].infoList,
+      count: fillRes[ck].infoList.length,
     };
 
-    let [vertices, uvs, normals] = genFaceArrays(t, blocks, chunkBlocks);
-    vertices = new Float32Array(vertices);
-    uvs = new Float32Array(uvs);
-    normals = new Float32Array(normals);
+    const draw = packDrawArrays(genFaceArrays(t, blocks, chunkBlocks));
 
-    fillRes[cn] = {
-      keys: fillRes[cn].infoList,
-      count: fillRes[cn].infoList.length,
+    fillRes[ck] = {
+      keys: fillRes[ck].infoList,
+      count: fillRes[ck].infoList.length,
       visible: false,
-      draw: {
-        rere: false,
-        vertices,
-        uvs,
-        normals,
-      },
+      draw: { rere: false, ...draw },
     };
   });
   return [blocks, fillRes];

--- a/src/world/atlas.js
+++ b/src/world/atlas.js
@@ -1,19 +1,51 @@
-// Texture atlas lookup for allMinecraft.jpeg.
-// The atlas is a 16x16 grid; each entry is the 1-indexed [column, row]
-// of a tile counted from the bottom-left of the image.
+// Texture atlas lookup for allMinecraft.jpeg (classic terrain.png layout).
+// The atlas is a 16x16 grid; tiles are 1-indexed [column, row] counted from
+// the bottom-left of the image.
 export const ATLAS_GRID_SIZE = 16;
 export const ATLAS_UV_SIZE = 1 / ATLAS_GRID_SIZE;
 
+// Either a single [col, row] tile for all faces, or { top, side, bottom }.
 export const AMTmap = {
+  grass: { top: [1, 16], side: [4, 16], bottom: [3, 16] },
   dirt: [3, 16],
+  stone: [2, 16],
+  cobblestone: [1, 15],
   wood: [5, 16],
-  grass: [5, 3],
   sand: [3, 15],
   ground: [8, 11],
-  barktop: [6, 15],
-  log: [5, 15],
+  log: { top: [6, 15], side: [5, 15], bottom: [6, 15] },
   bedrock: [2, 15],
-  glass: [3, 5],
+  glass: [2, 13],
+  leaves: [5, 13],
+  water: [15, 4], // not used for rendering (water draws as tinted material)
 };
 
 export const AMTmapkeys = Object.keys(AMTmap);
+
+// face: "top" | "side" | "bottom"
+export function tileFor(texture, face) {
+  const entry = AMTmap[texture] || AMTmap.dirt;
+  if (Array.isArray(entry)) {
+    return entry;
+  }
+  return entry[face] || entry.side;
+}
+
+// Blocks rendered in the transparent pass (tinted material, no atlas map).
+// Leaves/glass stay opaque because the atlas is a JPEG with no alpha channel
+// (same trade-off as Minecraft's "fast graphics" leaves).
+export const TRANSPARENT_TEXTURES = ["water"];
+
+// The classic grass-top tile is grayscale and gets tinted green; everything
+// else renders untinted. Values are RGB multipliers baked into vertex colors.
+export const GRASS_TINT = [0.55, 0.85, 0.4];
+
+// Classic Minecraft per-face shading, baked into vertex colors.
+export const FACE_SHADE = {
+  top: 1.0,
+  bottom: 0.5,
+  north: 0.8, // +-z faces
+  south: 0.8,
+  east: 0.6, // +-x faces
+  west: 0.6,
+};

--- a/src/world/chunkMath.js
+++ b/src/world/chunkMath.js
@@ -1,44 +1,45 @@
-// Chunk ids are laid out x-major: id = worldSize * chunkX + chunkZ,
-// where chunkX/chunkZ are the chunk's grid coordinates.
+// Chunks are identified by string keys "cx.cz" where cx/cz are the chunk's
+// grid coordinates (floor(blockX / chunkSize)). The world is unbounded, so
+// coordinates can be negative.
 
-export function chunkIdToXY(id, worldSize) {
-  const y = Math.floor(id / worldSize);
-  const x = id - y * worldSize;
-  return { x, y };
+export function chunkKey(cx, cz) {
+  return cx + "." + cz;
 }
 
-export function distBetweenChunks(idA, idB, worldSize) {
-  const a = chunkIdToXY(idA, worldSize);
-  const b = chunkIdToXY(idB, worldSize);
-  return ((a.x - b.x) ** 2 + (a.y - b.y) ** 2) ** 0.5;
+export function parseChunkKey(key) {
+  const [cx, cz] = key.split(".").map(Number);
+  return { cx, cz };
 }
 
-export function chunkIdFromPosition(x, z, { worldSize, chunkSize }) {
-  return worldSize * Math.floor(x / chunkSize) + Math.floor(z / chunkSize);
+export function chunkCoordsFromPosition(x, z, chunkSize) {
+  return { cx: Math.floor(x / chunkSize), cz: Math.floor(z / chunkSize) };
 }
 
-// All chunk ids within `radius` (euclidean, in chunk units) of currentChunk,
-// clipped to the world bounds.
-export function getNearbyChunkIds(currentChunk, radius, worldSize) {
-  const nearby = new Set();
-  const cc = chunkIdToXY(currentChunk, worldSize);
+export function chunkKeyFromPosition(x, z, chunkSize) {
+  const { cx, cz } = chunkCoordsFromPosition(x, z, chunkSize);
+  return chunkKey(cx, cz);
+}
 
-  for (let x = -radius; x <= radius; x++) {
-    for (let y = -radius; y <= radius; y++) {
-      const id = currentChunk + worldSize * y + x;
-      if (id < 0 || id >= worldSize * worldSize) {
+export function distBetweenChunks(keyA, keyB) {
+  const a = parseChunkKey(keyA);
+  const b = parseChunkKey(keyB);
+  return ((a.cx - b.cx) ** 2 + (a.cz - b.cz) ** 2) ** 0.5;
+}
+
+// All chunk keys within `radius` (euclidean, in chunk units) of centerKey.
+export function getNearbyChunkKeys(centerKey, radius) {
+  const { cx, cz } = parseChunkKey(centerKey);
+  const nearby = [];
+  const r = Math.ceil(radius);
+
+  for (let dx = -r; dx <= r; dx++) {
+    for (let dz = -r; dz <= r; dz++) {
+      if ((dx ** 2 + dz ** 2) ** 0.5 > radius) {
         continue;
       }
-
-      const p = chunkIdToXY(id, worldSize);
-      const chunkDist = ((p.x - cc.x) ** 2 + (p.y - cc.y) ** 2) ** 0.5;
-      if (chunkDist > radius) {
-        continue;
-      }
-
-      nearby.add(id);
+      nearby.push(chunkKey(cx + dx, cz + dz));
     }
   }
 
-  return [...nearby];
+  return nearby;
 }

--- a/src/world/edits.js
+++ b/src/world/edits.js
@@ -1,0 +1,64 @@
+import { makeKey } from "./keys";
+import { chunkKeyFromPosition } from "./chunkMath";
+
+// The world is fully determined by (seed + edits). An edit is a block the
+// player added or removed relative to the generated terrain:
+//   { type: "add", pos: [x,y,z], texture } | { type: "remove", pos }
+// Edits are applied by the chunk worker at generation time, so they survive
+// for chunks that don't exist yet (remote replay, persistence reload).
+// Keyed by block key; the latest edit for a position wins.
+
+let edits = {};
+let storageKey = null;
+let saveTimer = null;
+
+export function recordEdit(event, persist) {
+  edits[makeKey(...event.pos)] = event;
+  if (persist) {
+    scheduleSave();
+  }
+}
+
+// Returns { blockKey -> edit } for edits that fall inside the given chunks.
+export function editsForChunks(chunkKeys, chunkSize) {
+  const wanted = new Set(chunkKeys);
+  const result = {};
+  for (const [key, event] of Object.entries(edits)) {
+    const ck = chunkKeyFromPosition(event.pos[0], event.pos[2], chunkSize);
+    if (wanted.has(ck)) {
+      result[key] = event;
+    }
+  }
+  return result;
+}
+
+export function loadEdits(seed) {
+  storageKey = `clonecraft-edits-${seed}`;
+  try {
+    edits = JSON.parse(window.localStorage.getItem(storageKey)) || {};
+  } catch {
+    edits = {};
+  }
+  return Object.keys(edits).length;
+}
+
+export function clearEdits() {
+  edits = {};
+  if (storageKey) {
+    window.localStorage.removeItem(storageKey);
+  }
+}
+
+function scheduleSave() {
+  if (!storageKey || saveTimer) {
+    return;
+  }
+  saveTimer = setTimeout(() => {
+    saveTimer = null;
+    try {
+      window.localStorage.setItem(storageKey, JSON.stringify(edits));
+    } catch (err) {
+      console.warn("Could not save world edits:", err);
+    }
+  }, 1000);
+}

--- a/src/world/meshGen.js
+++ b/src/world/meshGen.js
@@ -1,37 +1,70 @@
 import { makeKey } from "./keys";
-import { AMTmap, ATLAS_UV_SIZE } from "./atlas";
+import {
+  tileFor,
+  ATLAS_UV_SIZE,
+  TRANSPARENT_TEXTURES,
+  GRASS_TINT,
+  FACE_SHADE,
+} from "./atlas";
 
-// Builds flat vertex/uv/normal arrays for every exposed face of a chunk.
-// `t` is the block half-thickness, `blocks` must contain the chunk's blocks
-// plus their neighbors so faces shared with adjacent chunks get culled.
+function faceUVs(texture, face) {
+  const [col, row] = tileFor(texture, face);
+  const uvL = (col - 1) * ATLAS_UV_SIZE;
+  const uvB = (row - 1) * ATLAS_UV_SIZE;
+  return [
+    uvL + ATLAS_UV_SIZE,
+    uvB + 0,
+    uvL + ATLAS_UV_SIZE,
+    uvB + ATLAS_UV_SIZE,
+    uvL + 0,
+    uvB + 0,
+    uvL + 0,
+    uvB + 0,
+    uvL + ATLAS_UV_SIZE,
+    uvB + ATLAS_UV_SIZE,
+    uvL + 0,
+    uvB + ATLAS_UV_SIZE,
+  ];
+}
+
+function isTransparent(texture) {
+  return TRANSPARENT_TEXTURES.includes(texture);
+}
+
+// A face is hidden when its neighbor fully covers it:
+// - opaque blocks cull against opaque neighbors
+// - transparent blocks cull against the same texture (water-water,
+//   glass-glass) and against opaque neighbors
+function faceHidden(texture, neighbor) {
+  if (!neighbor) {
+    return false;
+  }
+  if (!isTransparent(neighbor.texture)) {
+    return true;
+  }
+  return neighbor.texture === texture;
+}
+
+// Builds flat vertex/uv/normal/color arrays for every exposed face of a
+// chunk, split into an opaque set and a transparent (water/glass/leaves)
+// set. `t` is the block half-thickness; `blocks` must contain the chunk's
+// blocks plus neighbors so faces shared with adjacent chunks get culled.
 export function genFaceArrays(t, blocks, chunkBlocks) {
   const t2 = 2 * t;
-  const vertices = [];
-  const uvs = [];
-  const normals = [];
+  const out = {
+    solid: { vertices: [], uvs: [], normals: [], colors: [] },
+    trans: { vertices: [], uvs: [], normals: [], colors: [] },
+  };
 
   chunkBlocks.keys.forEach((cen) => {
+    const block = blocks[cen];
+    if (!block) {
+      return;
+    }
     let [nx, ny, nz] = cen.split(".");
-    const [x, y, z] = blocks[cen].pos;
-
-    const currtexture = blocks[cen].texture;
-    const uvL = (AMTmap[currtexture][0] - 1) * ATLAS_UV_SIZE;
-    const uvB = (AMTmap[currtexture][1] - 1) * ATLAS_UV_SIZE;
-    const onefaceuv = [
-      //uv means UxV meaning (u,v) meaning u is the x cordinate v is the y
-      uvL + ATLAS_UV_SIZE,
-      uvB + 0,
-      uvL + ATLAS_UV_SIZE,
-      uvB + ATLAS_UV_SIZE,
-      uvL + 0,
-      uvB + 0,
-      uvL + 0,
-      uvB + 0,
-      uvL + ATLAS_UV_SIZE,
-      uvB + ATLAS_UV_SIZE,
-      uvL + 0,
-      uvB + ATLAS_UV_SIZE,
-    ];
+    const [x, y, z] = block.pos;
+    const texture = block.texture;
+    const target = isTransparent(texture) ? out.trans : out.solid;
 
     nx = Number(nx);
     ny = Number(ny);
@@ -47,40 +80,84 @@ export function genFaceArrays(t, blocks, chunkBlocks) {
     c[7] = [x - t, y + t, z - t];
     c[8] = [x + t, y + t, z - t];
 
-    function pushFace(corners, normal) {
-      vertices.push(...corners[0], ...corners[1], ...corners[2]);
-      vertices.push(...corners[3], ...corners[4], ...corners[5]);
+    function pushFace(corners, normal, face, shade) {
+      target.vertices.push(...corners[0], ...corners[1], ...corners[2]);
+      target.vertices.push(...corners[3], ...corners[4], ...corners[5]);
+      const tint =
+        texture === "grass" && face === "top" ? GRASS_TINT : [1, 1, 1];
       for (let i = 0; i < 6; i++) {
-        normals.push(...normal);
+        target.normals.push(...normal);
+        target.colors.push(tint[0] * shade, tint[1] * shade, tint[2] * shade);
       }
-      uvs.push(...onefaceuv);
+      target.uvs.push(...faceUVs(texture, face));
     }
 
     // front (+z)
-    if (!blocks[makeKey(nx, ny, nz + t2)]) {
-      pushFace([c[1], c[4], c[2], c[2], c[4], c[3]], [0, 0, 1]);
+    if (!faceHidden(texture, blocks[makeKey(nx, ny, nz + t2)])) {
+      pushFace(
+        [c[1], c[4], c[2], c[2], c[4], c[3]],
+        [0, 0, 1],
+        "side",
+        FACE_SHADE.north,
+      );
     }
     // back (-z)
-    if (!blocks[makeKey(nx, ny, nz - t2)]) {
-      pushFace([c[6], c[7], c[5], c[5], c[7], c[8]], [0, 0, -1]);
+    if (!faceHidden(texture, blocks[makeKey(nx, ny, nz - t2)])) {
+      pushFace(
+        [c[6], c[7], c[5], c[5], c[7], c[8]],
+        [0, 0, -1],
+        "side",
+        FACE_SHADE.south,
+      );
     }
     // left (-x)
-    if (!blocks[makeKey(nx - t2, ny, nz)]) {
-      pushFace([c[2], c[3], c[6], c[6], c[3], c[7]], [-1, 0, 0]);
+    if (!faceHidden(texture, blocks[makeKey(nx - t2, ny, nz)])) {
+      pushFace(
+        [c[2], c[3], c[6], c[6], c[3], c[7]],
+        [-1, 0, 0],
+        "side",
+        FACE_SHADE.west,
+      );
     }
     // right (+x)
-    if (!blocks[makeKey(nx + t2, ny, nz)]) {
-      pushFace([c[5], c[8], c[1], c[1], c[8], c[4]], [1, 0, 0]);
+    if (!faceHidden(texture, blocks[makeKey(nx + t2, ny, nz)])) {
+      pushFace(
+        [c[5], c[8], c[1], c[1], c[8], c[4]],
+        [1, 0, 0],
+        "side",
+        FACE_SHADE.east,
+      );
     }
     // top (+y)
-    if (!blocks[makeKey(nx, ny + t2, nz)]) {
-      pushFace([c[4], c[8], c[3], c[3], c[8], c[7]], [0, 1, 0]);
+    if (!faceHidden(texture, blocks[makeKey(nx, ny + t2, nz)])) {
+      pushFace(
+        [c[4], c[8], c[3], c[3], c[8], c[7]],
+        [0, 1, 0],
+        "top",
+        FACE_SHADE.top,
+      );
     }
     // bottom (-y)
-    if (!blocks[makeKey(nx, ny - t2, nz)]) {
-      pushFace([c[5], c[1], c[6], c[6], c[1], c[2]], [0, -1, 0]);
+    if (!faceHidden(texture, blocks[makeKey(nx, ny - t2, nz)])) {
+      pushFace(
+        [c[5], c[1], c[6], c[6], c[1], c[2]],
+        [0, -1, 0],
+        "bottom",
+        FACE_SHADE.bottom,
+      );
     }
   });
 
-  return [vertices, uvs, normals];
+  return out;
+}
+
+// Packs a genFaceArrays result into typed arrays ready for postMessage.
+export function packDrawArrays(arrays) {
+  const pack = (set) => ({
+    vertices: new Float32Array(set.vertices),
+    uvs: new Float32Array(set.uvs),
+    normals: new Float32Array(set.normals),
+    colors: new Float32Array(set.colors),
+  });
+  return { solid: pack(arrays.solid), trans: pack(arrays.trans) };
 }


### PR DESCRIPTION
Stacked on #12 (base branch is `big-cleanup`). Implements 8 of the roadmap issues.

## Engine (commit 1)
- **#27 Infinite world** — chunks are coordinate-keyed (`"cx.cz"`, negatives included) and generate on demand as the player moves; world-edge clamps removed; void respawn added
- **#18 Terrain layers + per-face textures** — grass/dirt/stone/bedrock strata, grass-top/side/bottom atlas tiles, two-octave height noise, sand beaches, classic per-face shading + grass tint baked into vertex colors
- **#28 Water** — low terrain fills to sea level; water renders semi-transparent in a separate pass; players sink slowly and swim up with Space
- **#26 Persistence** — world state = seed + edits overlay; every add/remove is recorded and applied by the worker at chunk-generation time. The same mechanism powers offline localStorage saves (per seed), multiplayer pre-join replay, and edits to not-yet-generated chunks
- **#21 Fog** — distance fog matched to the view radius hides the chunk edge

## UI + multiplayer polish (commit 2)
- **Title screen** — Minecraft-style dirt-tiled screen with player name, world seed, and Singleplayer/Multiplayer selection; connection now starts *after* mode choice, with offline fallback
- **Loading screen** — green blocky progress bar; actually disappears when the build finishes
- **#14 Hotbar** — 9 slots, always visible, active-slot highlight, keeps 1-5/wheel selection
- **#23 Click-to-play + pause** — pointer-lock overlay with controls cheat-sheet; Esc shows pause menu (Back to Game / Quit to Title)
- **#25 Remote players** — blocky Steve avatars, frame-rate-independent lerp between 10 Hz heartbeats, floating name tags; names entered on the title screen sync via the server

Pairs with GreyDaCaLa/ReactMineCraftCloneServer#1 (player names + terrain-removal tracking).

Refs #14 #18 #21 #23 #25 #26 #27 #28

## Test plan (all verified live in browser)
- [x] Title screen inputs + mode selection feed config; custom seed generates a different world
- [x] Terrain strata visible when digging; per-face grass textures; beaches around lakes
- [x] Walked/teleported to (200,200) and negative coords — chunks stream in, 120 FPS
- [x] Dug a hole, reloaded — hole persists via localStorage edits (offline)
- [x] Swam in a lake (slow sink, Space to rise)
- [x] Fake networked player renders as named, smoothly-moving Steve; remote block add appears
- [x] `npx eslint src` → 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)