### PR TITLE
Sound effects: place/break/footsteps + ambient (#17)

### DIFF
--- a/src/components/CoreGame.js
+++ b/src/components/CoreGame.js
@@ -13,8 +13,9 @@ import { Clouds } from "./effects/Clouds";
 import { BlockOutline } from "./effects/BlockOutline";
 import { HeldBlock } from "./effects/HeldBlock";
 import LowerControlStrip from "../hooks/LowerControlStrip";
-import { useRef, useState } from "react";
+import { useRef, useState, useEffect } from "react";
 import { useControls } from "leva";
+import { toggleSound, startAmbient } from "../world/sound";
 
 const MIN_RADIUS = 3;
 const MAX_RADIUS = 8;
@@ -91,6 +92,26 @@ const CoreGame = () => {
   function updateInitStatus(obj) {
     setInitStatus((prev) => ({ ...prev, ...obj }));
   }
+
+  // M toggles sound; start the ambient pad on the first user gesture (audio
+  // can't begin until the browser has seen one)
+  useEffect(() => {
+    function onKey(e) {
+      if (e.code === "KeyM") {
+        toggleSound();
+      }
+    }
+    function startOnce() {
+      startAmbient();
+      window.removeEventListener("pointerdown", startOnce);
+    }
+    window.addEventListener("keydown", onKey);
+    window.addEventListener("pointerdown", startOnce);
+    return () => {
+      window.removeEventListener("keydown", onKey);
+      window.removeEventListener("pointerdown", startOnce);
+    };
+  }, []);
 
   const fogFar = viewRadius * settings.worldSettings.chunkSize;
   return (

--- a/src/components/UIComponents/PauseOverlay.js
+++ b/src/components/UIComponents/PauseOverlay.js
@@ -8,6 +8,7 @@ const CONTROLS = [
   ["Left click", "Place block"],
   ["Right click", "Break block"],
   ["1-5 / Wheel", "Select block"],
+  ["M", "Mute sound"],
   ["Esc", "Pause"],
 ];
 

--- a/src/components/cubeComponents/Chunk.jsx
+++ b/src/components/cubeComponents/Chunk.jsx
@@ -5,6 +5,7 @@ import { useRef, useState } from "react";
 import settings from "../../constants";
 import { makeKey } from "../../world/keys";
 import { useStore } from "../../hooks/useStore";
+import { playPlace, playBreak } from "../../world/sound";
 
 export const Chunk = ({
   chunkKey,
@@ -66,6 +67,7 @@ export const Chunk = ({
           return;
         }
         applyBlockChange({ type: "add", pos: blockToAdd, texture });
+        playPlace();
         if (settings.onlineEnabled) {
           online_addCube(blockToAdd, texture);
         }
@@ -78,6 +80,7 @@ export const Chunk = ({
           return;
         }
         applyBlockChange({ type: "remove", pos: contactBlock });
+        playBreak();
         if (settings.onlineEnabled) {
           online_removeCube(contactBlock);
         }

--- a/src/components/playerComponents/Player.js
+++ b/src/components/playerComponents/Player.js
@@ -5,6 +5,7 @@ import settings from "../../constants";
 import { useKeyboard } from "../../hooks/useKeyboard";
 import { useStore } from "../../hooks/useStore";
 import { makeKey } from "../../world/keys";
+import { playFootstep } from "../../world/sound";
 import { FPV } from "./controls/FPV";
 
 const GRAVITY = -25; // units/s^2 -- gentle, for a floaty Minecraft-y arc
@@ -72,6 +73,7 @@ export const Player = ({ moveBools, playerStartingPostion, REF_ALLCUBES }) => {
   }
 
   const wasSprintingOnGround = useRef(false);
+  const stepDist = useRef(0); // distance walked since the last footstep sound
 
   function doMovement(dt) {
     checkFlyToggle();
@@ -442,6 +444,23 @@ export const Player = ({ moveBools, playerStartingPostion, REF_ALLCUBES }) => {
     pos.current[0] += vel.current[0] * dt;
     pos.current[1] += vel.current[1] * dt;
     pos.current[2] += vel.current[2] * dt;
+
+    // footsteps: one sound per stride while walking on solid ground
+    const horizSpeed = Math.hypot(vel.current[0], vel.current[2]);
+    if (
+      movementStatus.current.onGround &&
+      !movementStatus.current.flying &&
+      horizSpeed > 0.5
+    ) {
+      stepDist.current += horizSpeed * dt;
+      const stride = movementStatus.current.inWater ? 3.0 : 2.2;
+      if (stepDist.current >= stride) {
+        stepDist.current = 0;
+        playFootstep();
+      }
+    } else {
+      stepDist.current = 0;
+    }
 
     // fell out of the world (e.g. into an ungenerated chunk) -- respawn
     if (pos.current[1] < settings.worldSettings.minY - 20) {

--- a/src/world/sound.js
+++ b/src/world/sound.js
@@ -1,0 +1,151 @@
+// Procedural sound effects via the Web Audio API -- no asset files needed.
+//
+// A single, lazily-created AudioContext synthesizes short noise bursts for
+// placing/breaking blocks and footsteps, plus a quiet ambient wind pad.
+// Browsers require a user gesture before audio can start, so the context is
+// created/resumed on first use (placing or breaking a block is a click, so
+// by the time anything plays the gesture requirement is already satisfied).
+//
+// Hooked into the place/remove paths in Chunk.jsx and the movement loop in
+// Player.js. Press M in-game to mute/unmute.
+
+let ctx = null;
+let masterGain = null;
+let noiseBuffer = null;
+let enabled = true;
+let ambient = null; // { source, gain } once started
+
+function getCtx() {
+  if (typeof window === "undefined") {
+    return null;
+  }
+  if (!ctx) {
+    const AC = window.AudioContext || window.webkitAudioContext;
+    if (!AC) {
+      return null;
+    }
+    ctx = new AC();
+    masterGain = ctx.createGain();
+    masterGain.gain.value = 0.6;
+    masterGain.connect(ctx.destination);
+  }
+  if (ctx.state === "suspended") {
+    // resume() is a no-op (and harmless) when called outside a gesture; the
+    // first place/break click will successfully resume it
+    ctx.resume().catch(() => {});
+  }
+  return ctx;
+}
+
+// One second of white noise, reused by every burst.
+function getNoiseBuffer(c) {
+  if (!noiseBuffer) {
+    const len = Math.floor(c.sampleRate);
+    noiseBuffer = c.createBuffer(1, len, c.sampleRate);
+    const data = noiseBuffer.getChannelData(0);
+    for (let i = 0; i < len; i++) {
+      data[i] = Math.random() * 2 - 1;
+    }
+  }
+  return noiseBuffer;
+}
+
+// A short filtered-noise blip with a fast attack and exponential decay --
+// the building block for the chunky, lo-fi block sounds.
+function noiseBurst({ duration, gain, freq, q = 1, type = "lowpass", rate = 1 }) {
+  const c = getCtx();
+  if (!c || !enabled) {
+    return;
+  }
+  const now = c.currentTime;
+
+  const src = c.createBufferSource();
+  src.buffer = getNoiseBuffer(c);
+  src.loop = true;
+  // a random window into the noise keeps repeated sounds from sounding identical
+  src.loopStart = Math.random() * 0.5;
+  src.loopEnd = src.loopStart + 0.4;
+  src.playbackRate.value = rate;
+
+  const filter = c.createBiquadFilter();
+  filter.type = type;
+  filter.frequency.value = freq;
+  filter.Q.value = q;
+
+  const g = c.createGain();
+  g.gain.setValueAtTime(0.0001, now);
+  g.gain.exponentialRampToValueAtTime(gain, now + 0.006);
+  g.gain.exponentialRampToValueAtTime(0.0001, now + duration);
+
+  src.connect(filter);
+  filter.connect(g);
+  g.connect(masterGain);
+
+  src.start(now);
+  src.stop(now + duration + 0.05);
+}
+
+// Breaking a block: a longer, fuller crunch.
+export function playBreak() {
+  noiseBurst({ duration: 0.22, gain: 0.5, freq: 1400, q: 0.8 });
+}
+
+// Placing a block: a shorter, lower "thunk".
+export function playPlace() {
+  noiseBurst({ duration: 0.13, gain: 0.45, freq: 700, q: 1.1 });
+}
+
+// A footstep: very short and quiet, with a touch of random pitch so a run
+// doesn't sound robotic.
+export function playFootstep() {
+  noiseBurst({
+    duration: 0.09,
+    gain: 0.16,
+    freq: 420 + Math.random() * 260,
+    q: 0.7,
+    rate: 0.85 + Math.random() * 0.3,
+  });
+}
+
+// A continuous, barely-there wind pad for ambience. Safe to call repeatedly;
+// it only ever starts one source.
+export function startAmbient() {
+  const c = getCtx();
+  if (!c || ambient) {
+    return;
+  }
+  const src = c.createBufferSource();
+  src.buffer = getNoiseBuffer(c);
+  src.loop = true;
+
+  const filter = c.createBiquadFilter();
+  filter.type = "lowpass";
+  filter.frequency.value = 320;
+  filter.Q.value = 0.4;
+
+  const g = c.createGain();
+  g.gain.value = enabled ? 0.04 : 0;
+
+  src.connect(filter);
+  filter.connect(g);
+  g.connect(masterGain);
+  src.start();
+
+  ambient = { source: src, gain: g };
+}
+
+export function setSoundEnabled(on) {
+  enabled = on;
+  if (ambient) {
+    ambient.gain.gain.value = on ? 0.04 : 0;
+  }
+}
+
+export function isSoundEnabled() {
+  return enabled;
+}
+
+export function toggleSound() {
+  setSoundEnabled(!enabled);
+  return enabled;
+}


### PR DESCRIPTION
Closes #17.

Adds procedural sound effects synthesized at runtime with the **Web Audio API** — no CC0 audio files to download or bundle. Everything is generated from filtered white-noise bursts, so the PR adds zero binary assets.

## What's included
- **`src/world/sound.js`** — a small, lazily-initialized audio engine:
  - `playBreak()` / `playPlace()` — chunky lo-fi block sounds
  - `playFootstep()` — short, randomized-pitch step
  - `startAmbient()` — a barely-there looping wind pad
  - `toggleSound()` / `setSoundEnabled()` / `isSoundEnabled()` — mute control
- **`Chunk.jsx`** — plays place/break on the existing local place/remove paths.
- **`Player.js`** — plays a footstep once per stride while walking on the ground (longer stride while wading).
- **`CoreGame.js`** — `M` mutes/unmutes; ambient pad starts on the first user gesture (browsers block audio until then).
- **`PauseOverlay.js`** — documents the new `M` control.

## Design notes
- A single `AudioContext` is created on first use and `resume()`d (the place/break click satisfies the browser gesture requirement).
- One reused 1s noise buffer feeds every sound; bursts randomize the loop window and pitch so repeats don't sound identical.
- Sounds fire only on **local** actions (in `Chunk.jsx`), not on remote-player edits or persisted-edit replay, so loading a saved world stays silent.

## Testing
⚠️ I could not test audio playback in this environment. `CI=false npm run build` compiles cleanly. Please verify in-browser that place/break/footstep sounds play and `M` mutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)