### PR TITLE
Sand block with falling physics (#34)

### DIFF
--- a/src/components/cubeComponents/Cubes.jsx
+++ b/src/components/cubeComponents/Cubes.jsx
@@ -261,6 +261,41 @@ export const Cubes = ({
     });
   }
 
+  // ---- sand gravity (Minecraft-style) ----
+  // Sand only falls in response to a block update (placing it, or removing
+  // whatever was under it) -- it does not auto-collapse generated terrain.
+  // A falling block drops one cell per tick until something solid stops it,
+  // sinking through water on the way down.
+  const SAND_TICK_MS = 80;
+  const sandQueue = useRef([]);
+  const lastSandTick = useRef(0);
+
+  function tickSandFall() {
+    const now = performance.now();
+    if (!sandQueue.current.length || now - lastSandTick.current < SAND_TICK_MS) {
+      return;
+    }
+    lastSandTick.current = now;
+    const batch = sandQueue.current.splice(0, 128);
+    batch.forEach(([x, y, z]) => {
+      const here = REF_ALLCUBES.current[makeKey(x, y, z)];
+      if (!here || here.texture !== "sand") {
+        return;
+      }
+      if (y - 1 <= worldSettings.minY) {
+        return; // resting on the bedrock floor
+      }
+      const below = REF_ALLCUBES.current[makeKey(x, y - 1, z)];
+      // fall into empty space, or sink through water
+      if (!below || below.texture === "water") {
+        applyBlockChange({ type: "remove", pos: [x, y, z] });
+        applyBlockChange({ type: "add", pos: [x, y - 1, z], texture: "sand" });
+        // keep falling, and let any sand stacked above this column drop too
+        sandQueue.current.push([x, y - 1, z], [x, y + 1, z]);
+      }
+    });
+  }
+
   // Single entry point for every block mutation: local clicks, remote
   // players, and persisted-edit replay all flow through here.
   function applyBlockChange(event) {
@@ -269,9 +304,14 @@ export const Cubes = ({
     if (event.type === "remove") {
       // neighboring water may flow into the new hole
       enqueueFlowAround(event.pos);
+      // sand resting directly above the removed block is now unsupported
+      sandQueue.current.push([event.pos[0], event.pos[1] + 1, event.pos[2]]);
     } else if (event.texture === "water") {
       // newly placed/flowed water may keep spreading
       flowQueue.current.push([...event.pos]);
+    } else if (event.texture === "sand") {
+      // freshly placed sand may need to fall
+      sandQueue.current.push([...event.pos]);
     }
 
     const ck = chunkKeyFromPosition(
@@ -375,6 +415,7 @@ export const Cubes = ({
     }
 
     tickWaterFlow();
+    tickSandFall();
 
     // performance tuning changed the render distance
     if (lastRadius.current !== settings.viewRadius) {


### PR DESCRIPTION
Closes #34.

Makes sand obey gravity the way it does in current Minecraft. (Sand already existed as a block/texture; this adds the physics.)

## Behavior
- Sand falls **only in response to a block update** — when you place it, or when you break whatever was holding it up. Generated terrain is never scanned, so loading a desert/beach doesn't trigger a mass collapse (matches MC).
- A falling block drops **one cell per tick** until a solid block stops it.
- Sand **sinks through water**, displacing it, until it reaches the floor.
- Resting on the bedrock floor stops it.

## Implementation
Added `tickSandFall()` in `src/components/cubeComponents/Cubes.jsx`, modeled on the existing `tickWaterFlow()` tick loop and fed from the single `applyBlockChange` mutation path:
- placing sand → enqueue that cell;
- removing any block → enqueue the cell directly above (sand there may now be unsupported);
- after a step, the new cell and the one above are re-enqueued so columns cascade.

Because it's driven from `applyBlockChange`, it works the same for local clicks, remote-player edits, and persisted-edit replay.

## Notes / trade-offs
- The fall is **discrete** (one block per ~80ms tick), not a smooth falling-entity animation — keeps it simple and asset-free. Easy to tune via `SAND_TICK_MS`.
- Like the existing water system, each fall step records a persisted edit, so collapsing a tall sand column writes several edits. Acceptable and consistent with current water behavior.

## Testing
⚠️ Not playtested in-engine. `CI=false npm run build` compiles cleanly. Suggested manual check: place sand in mid-air (it should drop), dig under a sand pile (it should collapse), and drop sand into water (it should sink to the bottom).

🤖 Generated with [Claude Code](https://claude.com/claude-code)