### PR TITLE
Creative inventory + more block variety (#29)

### DIFF
--- a/src/components/CoreGame.js
+++ b/src/components/CoreGame.js
@@ -9,6 +9,7 @@ import { OrbitControls } from "@react-three/drei";
 import { LoadingWorldScreen } from "./UIComponents/LoadingWorldScreen";
 import PauseOverlay from "./UIComponents/PauseOverlay";
 import { PlayerList } from "./UIComponents/PlayerList";
+import { Inventory } from "./UIComponents/Inventory";
 import { DayNight } from "./effects/DayNight";
 import { Clouds } from "./effects/Clouds";
 import { BlockOutline } from "./effects/BlockOutline";
@@ -84,6 +85,38 @@ const CoreGame = () => {
     };
   }, []);
 
+  // E toggles the creative inventory. Opening it releases the pointer lock so
+  // the cursor can click blocks; closing re-locks to resume play. (PauseOverlay
+  // checks inventoryOpen so it stays hidden while the inventory is up.)
+  useEffect(() => {
+    if (settings.movewithJOY_BOOL) {
+      return; // touch devices use the on-screen UI, not pointer lock
+    }
+    function requestLock() {
+      const canvas = document.querySelector("canvas");
+      if (canvas) {
+        canvas.requestPointerLock();
+      }
+    }
+    function onKey(e) {
+      const st = useStore.getState();
+      if (e.code === "KeyE") {
+        if (st.inventoryOpen) {
+          st.setInventoryOpen(false);
+          requestLock();
+        } else if (document.pointerLockElement) {
+          // only open while actively playing (not from the pause/title screen)
+          st.setInventoryOpen(true);
+          document.exitPointerLock();
+        }
+      } else if (e.code === "Escape" && st.inventoryOpen) {
+        st.setInventoryOpen(false);
+      }
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
+
   const fogFar = viewRadius * settings.worldSettings.chunkSize;
   return (
     <>
@@ -125,6 +158,7 @@ const CoreGame = () => {
       {!settings.ignoreCameraFollowPlayer && <div className="cursor centered absolute">+</div>}
       <TextureSelector activeTextureREF={activeTextureREF} />
       <PlayerList />
+      <Inventory />
       <PauseOverlay />
     </>
   );

--- a/src/components/TextureSelector.js
+++ b/src/components/TextureSelector.js
@@ -1,49 +1,43 @@
 import { useEffect } from "react";
 import { useStore } from "../hooks/useStore";
-import { dirtImg, grassImg, glassImg, logImg, woodImg } from "../images/images";
+import { AtlasTile } from "./UIComponents/AtlasTile";
 
-const images = {
-  dirt: dirtImg,
-  grass: grassImg,
-  glass: glassImg,
-  wood: woodImg,
-  log: logImg,
-};
-
-const texturesArray = Object.keys(images);
-
-// 9 hotbar slots: first 5 have textures, last 4 are empty
-const HOTBAR_SLOTS = 9;
-
+// The hotbar. Slots and the selected index live in the store so the creative
+// inventory (E) can reassign them. The selected slot's block is mirrored into
+// store.texture + activeTextureREF, which the placement code reads.
 export const TextureSelector = ({ activeTextureREF }) => {
-  const [activeTexture, setTexture] = useStore((state) => [
-    state.texture,
-    state.setTexture,
-  ]);
+  const hotbar = useStore((s) => s.hotbar);
+  const selectedSlot = useStore((s) => s.selectedSlot);
+  const setTexture = useStore((s) => s.setTexture);
+
+  // keep the active placement texture in sync with the selected slot
+  useEffect(() => {
+    const tex = hotbar[selectedSlot] || "dirt";
+    setTexture(tex);
+    activeTextureREF.current = tex;
+  }, [hotbar, selectedSlot, setTexture, activeTextureREF]);
 
   useEffect(() => {
-    function pickTexture(texture) {
-      setTexture(texture);
-      activeTextureREF.current = texture;
-    }
-
     function handleWheel(event) {
-      const delta = Math.sign(event.deltaY);
-      const nextPos = texturesArray.indexOf(activeTexture) + delta;
-      if (nextPos >= 0 && nextPos < texturesArray.length) {
-        pickTexture(texturesArray[nextPos]);
+      const st = useStore.getState();
+      if (st.inventoryOpen) {
+        return; // wheel scrolls the inventory, not the hotbar
       }
+      const n = st.hotbar.length;
+      const delta = Math.sign(event.deltaY);
+      st.setSelectedSlot((st.selectedSlot + delta + n) % n);
     }
 
-    // 1-9 select hotbar slots directly (only filled slots respond)
+    // 1-9 select hotbar slots directly
     function handleKeyDown(event) {
       const m = /^Digit([1-9])$/.exec(event.code);
       if (!m) {
         return;
       }
+      const st = useStore.getState();
       const slot = Number(m[1]) - 1;
-      if (texturesArray[slot]) {
-        pickTexture(texturesArray[slot]);
+      if (slot < st.hotbar.length) {
+        st.setSelectedSlot(slot);
       }
     }
 
@@ -53,25 +47,18 @@ export const TextureSelector = ({ activeTextureREF }) => {
       window.removeEventListener("wheel", handleWheel);
       document.removeEventListener("keydown", handleKeyDown);
     };
-  }, [setTexture, activeTexture, activeTextureREF]);
-
-  const slots = Array.from({ length: HOTBAR_SLOTS }, (_, i) => {
-    const key = texturesArray[i] || null;
-    return { key, src: key ? images[key] : null };
-  });
+  }, []);
 
   return (
     <div className="hotbar">
-      {slots.map((slot, i) => {
-        const isActive = slot.key === activeTexture;
+      {hotbar.map((key, i) => {
+        const isActive = i === selectedSlot;
         return (
           <div
             key={i}
             className={`hotbar__slot${isActive ? " hotbar__slot--active" : ""}`}
           >
-            {slot.src && (
-              <img src={slot.src} alt={slot.key} className="hotbar__img" />
-            )}
+            {key && <AtlasTile texture={key} size={38} />}
           </div>
         );
       })}

--- a/src/components/UIComponents/AtlasTile.js
+++ b/src/components/UIComponents/AtlasTile.js
@@ -1,0 +1,27 @@
+import { allMinecraft } from "../../images/images";
+import { tileFor, ATLAS_GRID_SIZE } from "../../world/atlas";
+
+// Renders a single texture-atlas tile as a pixelated thumbnail using a CSS
+// background, so the whole block palette comes straight from allMinecraft.jpeg
+// without separate per-block image files. `face` picks which face of a
+// multi-face block to show (default "side").
+export function AtlasTile({ texture, size = 38, face = "side" }) {
+  const [col, row] = tileFor(texture, face);
+  const N = ATLAS_GRID_SIZE; // 16
+  // tiles are 1-indexed from the bottom-left; CSS background-position counts y
+  // from the top, so invert the row
+  const posX = ((col - 1) / (N - 1)) * 100;
+  const posY = ((N - row) / (N - 1)) * 100;
+  return (
+    <div
+      style={{
+        width: size,
+        height: size,
+        backgroundImage: `url(${allMinecraft})`,
+        backgroundSize: `${N * 100}% ${N * 100}%`,
+        backgroundPosition: `${posX}% ${posY}%`,
+        imageRendering: "pixelated",
+      }}
+    />
+  );
+}

--- a/src/components/UIComponents/Inventory.js
+++ b/src/components/UIComponents/Inventory.js
@@ -1,0 +1,70 @@
+import { useStore } from "../../hooks/useStore";
+import { AMTmapkeys } from "../../world/atlas";
+import { AtlasTile } from "./AtlasTile";
+
+// Blocks that exist in the atlas but aren't offered as placeable items.
+const HIDDEN = new Set(["water", "ground"]);
+const BLOCKS = AMTmapkeys.filter((k) => !HIDDEN.has(k));
+
+// turn "mossyCobblestone" into "Mossy Cobblestone" for tooltips/labels
+function prettyName(key) {
+  return key
+    .replace(/([A-Z])/g, " $1")
+    .replace(/^./, (c) => c.toUpperCase());
+}
+
+// Creative-style inventory. Open with E, click a block to drop it into the
+// currently selected hotbar slot (click a hotbar slot below to change which).
+export function Inventory() {
+  const inventoryOpen = useStore((s) => s.inventoryOpen);
+  const hotbar = useStore((s) => s.hotbar);
+  const selectedSlot = useStore((s) => s.selectedSlot);
+  const setHotbarSlot = useStore((s) => s.setHotbarSlot);
+  const setSelectedSlot = useStore((s) => s.setSelectedSlot);
+  const setInventoryOpen = useStore((s) => s.setInventoryOpen);
+
+  if (!inventoryOpen) {
+    return null;
+  }
+
+  return (
+    <div className="inventory" onClick={() => setInventoryOpen(false)}>
+      <div className="inventory__panel" onClick={(e) => e.stopPropagation()}>
+        <h2 className="inventory__title">Creative Inventory</h2>
+        <p className="inventory__hint">
+          Click a block to put it in hotbar slot {selectedSlot + 1}. Press E or
+          Esc to close.
+        </p>
+
+        <div className="inventory__grid">
+          {BLOCKS.map((block) => (
+            <button
+              key={block}
+              type="button"
+              className="inventory__cell"
+              title={prettyName(block)}
+              onClick={() => setHotbarSlot(selectedSlot, block)}
+            >
+              <AtlasTile texture={block} size={40} />
+            </button>
+          ))}
+        </div>
+
+        <div className="inventory__hotbar">
+          {hotbar.map((key, i) => (
+            <button
+              key={i}
+              type="button"
+              className={`inventory__slot${
+                i === selectedSlot ? " inventory__slot--active" : ""
+              }`}
+              onClick={() => setSelectedSlot(i)}
+            >
+              {key && <AtlasTile texture={key} size={34} />}
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/UIComponents/PauseOverlay.js
+++ b/src/components/UIComponents/PauseOverlay.js
@@ -12,6 +12,7 @@ const CONTROLS = [
   ["Right click", "Break block"],
   ["1-9 / Wheel", "Select block"],
   ["M", "Mute sound"],
+  ["E", "Inventory"],
   ["Esc", "Pause"],
 ];
 
@@ -83,6 +84,8 @@ const PauseOverlay = () => {
   const [overwriteId, setOverwriteId] = useState(null);
   const [saves, setSaves] = useState([]);
 
+  const inventoryOpen = useStore((s) => s.inventoryOpen);
+
   useEffect(() => {
     function onLockChange() {
       const isLocked = !!document.pointerLockElement;
@@ -96,6 +99,10 @@ const PauseOverlay = () => {
 
   // Don't render anything on touch/joystick devices
   if (settings.movewithJOY_BOOL) return null;
+
+  // The creative inventory releases pointer lock on purpose — don't treat that
+  // as a pause
+  if (inventoryOpen) return null;
 
   // Pointer is locked — game is running, no overlay needed
   if (locked) return null;

--- a/src/components/effects/HeldBlock.jsx
+++ b/src/components/effects/HeldBlock.jsx
@@ -1,21 +1,8 @@
 import { useRef, useEffect, useMemo } from "react";
 import { useFrame, useThree } from "@react-three/fiber";
-import {
-  dirtTexture,
-  grassTexture,
-  glassTexture,
-  woodTexture,
-  logTexture,
-} from "../../images/textures";
+import { allMincraftTexture } from "../../images/textures";
+import { tileFor, ATLAS_GRID_SIZE } from "../../world/atlas";
 import { useStore } from "../../hooks/useStore";
-
-const TEXTURE_MAP = {
-  dirt: dirtTexture,
-  grass: grassTexture,
-  glass: glassTexture,
-  wood: woodTexture,
-  log: logTexture,
-};
 
 export function HeldBlock() {
   const { camera } = useThree();
@@ -27,7 +14,16 @@ export function HeldBlock() {
   const bobTime = useRef(0);
   const swingRef = useRef(0);
 
-  const tex = useMemo(() => TEXTURE_MAP[texture] || dirtTexture, [texture]);
+  // show the held block by clipping the shared atlas down to its side tile;
+  // works for every block in the atlas, not just the few with standalone PNGs
+  const tex = useMemo(() => {
+    const [col, row] = tileFor(texture, "side");
+    const t = allMincraftTexture.clone();
+    t.needsUpdate = true;
+    t.repeat.set(1 / ATLAS_GRID_SIZE, 1 / ATLAS_GRID_SIZE);
+    t.offset.set((col - 1) / ATLAS_GRID_SIZE, (row - 1) / ATLAS_GRID_SIZE);
+    return t;
+  }, [texture]);
 
   useEffect(() => {
     const onPointerDown = () => {

--- a/src/hooks/useStore.js
+++ b/src/hooks/useStore.js
@@ -48,6 +48,22 @@ export const useStore = create((set, get) => ({
   autoAdjustViewRadius: (delta) =>
     set((s) => (s.renderDistanceAuto ? { viewRadius: applyViewRadius(s.viewRadius + delta) } : {})),
 
+  // 9 hotbar slots, each holding a block name; the selected slot is the
+  // block that gets placed. Assignable from the creative inventory (E).
+  hotbar: [
+    "grass",
+    "dirt",
+    "stone",
+    "cobblestone",
+    "sand",
+    "log",
+    "wood",
+    "glass",
+    "leaves",
+  ],
+  selectedSlot: 0,
+  inventoryOpen: false,
+
   establishedConn: false,
   socket: null,
   players: {},
@@ -57,6 +73,20 @@ export const useStore = create((set, get) => ({
     set(() => ({
       texture,
     }));
+  },
+
+  setSelectedSlot: (selectedSlot) => {
+    set(() => ({ selectedSlot }));
+  },
+  setHotbarSlot: (index, block) => {
+    set((state) => {
+      const hotbar = [...state.hotbar];
+      hotbar[index] = block;
+      return { hotbar };
+    });
+  },
+  setInventoryOpen: (inventoryOpen) => {
+    set(() => ({ inventoryOpen }));
   },
 
   online_addCube: (pos, texture) => {

--- a/src/index.css
+++ b/src/index.css
@@ -808,6 +808,111 @@ body {
   display: block;
 }
 
+/* ── Creative Inventory ─────────────────────────────────────────── */
+
+.inventory {
+  position: fixed;
+  inset: 0;
+  z-index: 85;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.55);
+}
+
+.inventory__panel {
+  background: rgba(0, 0, 0, 0.85);
+  border: 3px solid #555;
+  border-top-color: #888;
+  border-left-color: #888;
+  border-bottom-color: #222;
+  border-right-color: #222;
+  padding: 22px 26px 20px;
+  width: min(520px, 92vw);
+  max-height: 86vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.inventory__title {
+  font-family: "Courier New", Courier, monospace;
+  font-size: 20px;
+  font-weight: bold;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  color: #fff;
+  text-shadow: 2px 2px 0 #000;
+  margin: 0 0 6px 0;
+  text-align: center;
+}
+
+.inventory__hint {
+  font-family: "Courier New", Courier, monospace;
+  font-size: 11px;
+  letter-spacing: 1px;
+  color: #bbb;
+  text-shadow: 1px 1px 0 #000;
+  margin: 0 0 16px 0;
+  text-align: center;
+}
+
+.inventory__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(48px, 1fr));
+  gap: 6px;
+  overflow-y: auto;
+  padding: 4px;
+  margin-bottom: 16px;
+}
+
+.inventory__cell {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 5px;
+  background: rgba(20, 20, 20, 0.7);
+  border: 2px solid #444;
+  border-top-color: #222;
+  border-left-color: #222;
+  border-bottom-color: #666;
+  border-right-color: #666;
+  cursor: pointer;
+  transition: transform 0.07s ease, border-color 0.07s ease;
+}
+
+.inventory__cell:hover {
+  border-color: #fff;
+  transform: scale(1.08);
+}
+
+.inventory__hotbar {
+  display: flex;
+  gap: 4px;
+  justify-content: center;
+  border-top: 1px solid rgba(255, 255, 255, 0.12);
+  padding-top: 14px;
+}
+
+.inventory__slot {
+  width: 46px;
+  height: 46px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(20, 20, 20, 0.7);
+  border: 2px solid #444;
+  border-top-color: #222;
+  border-left-color: #222;
+  border-bottom-color: #666;
+  border-right-color: #666;
+  cursor: pointer;
+}
+
+.inventory__slot--active {
+  border: 3px solid #fff;
+  box-shadow: inset 0 0 0 1px #aaa;
+}
+
 /* ── Pause / Click-to-play Overlay ──────────────────────────────── */
 
 .pause-overlay {

--- a/src/world/atlas.js
+++ b/src/world/atlas.js
@@ -5,6 +5,8 @@ export const ATLAS_GRID_SIZE = 16;
 export const ATLAS_UV_SIZE = 1 / ATLAS_GRID_SIZE;
 
 // Either a single [col, row] tile for all faces, or { top, side, bottom }.
+// Tiles are 1-indexed [col, row] from the bottom-left of the 16x16 atlas, i.e.
+// [tx + 1, 16 - ty] for the (tx, ty) tile of the classic terrain.png layout.
 export const AMTmap = {
   grass: { top: [1, 16], side: [4, 16], bottom: [3, 16] },
   dirt: [3, 16],
@@ -19,6 +21,27 @@ export const AMTmap = {
   leaves: [5, 13],
   cactus: { top: [6, 12], side: [7, 12], bottom: [8, 12] },
   water: [15, 4], // not used for rendering (water draws as tinted material)
+
+  // ── extra placeable blocks (creative inventory) ──────────────────
+  gravel: [4, 15],
+  brick: [8, 16],
+  bookshelf: { top: [5, 16], side: [4, 14], bottom: [5, 16] },
+  mossyCobblestone: [5, 14],
+  obsidian: [6, 14],
+  sponge: [1, 13],
+  wool: [1, 12],
+  snow: [3, 12],
+  ice: [4, 12],
+  clay: [9, 12],
+  coalOre: [3, 14],
+  ironOre: [2, 14],
+  goldOre: [1, 14],
+  diamondOre: [3, 13],
+  redstoneOre: [4, 13],
+  ironBlock: [7, 15],
+  goldBlock: [8, 15],
+  diamondBlock: [9, 15],
+  tnt: { top: [10, 16], side: [9, 16], bottom: [11, 16] },
 };
 
 export const AMTmapkeys = Object.keys(AMTmap);


### PR DESCRIPTION
Closes #29.

Exposes far more of the texture atlas as placeable blocks and adds a **creative-style inventory** (press **E**) that assigns blocks to the hotbar. `AMTmap` in `src/world/atlas.js` stays the single source of truth — the inventory and hotbar both render directly from it.

## What's new
- **19 new placeable blocks** in `atlas.js`: gravel, brick, bookshelf, mossy cobblestone, obsidian, sponge, wool, snow, ice, clay, coal/iron/gold/diamond/redstone ore, iron/gold/diamond blocks, and TNT — using verified classic terrain.png tile coordinates (`[col, row] = [tx+1, 16-ty]`).
- **`AtlasTile`** (`UIComponents/AtlasTile.js`): renders any block's thumbnail straight from `allMinecraft.jpeg` via a CSS background — no per-block PNGs required.
- **`Inventory`** (`UIComponents/Inventory.js`): a grid of every placeable block. Click a block to drop it into the selected hotbar slot; the hotbar is shown at the bottom of the panel so you can click a slot to choose which one to fill.
- **Hotbar rewrite** (`TextureSelector.js`): now renders from the store + atlas. `1-9` and the scroll wheel select slots; the selected slot drives block placement.
- **Held block** (`HeldBlock.jsx`): now shows the correct atlas tile for **every** block (clips a cloned atlas texture to the block's side tile) instead of only the 5 that had standalone PNGs.

## State & controls
- New store fields: `hotbar` (9 slots), `selectedSlot`, `inventoryOpen` + setters.
- `E` opens/closes the inventory. Opening releases pointer lock so the cursor can click; closing re-locks to resume. `Esc` also closes it.
- `PauseOverlay` checks `inventoryOpen` so the "Game Paused" screen doesn't pop up when the inventory deliberately releases pointer lock.

## Out of scope (per the issue)
Survival mechanics — drops, crafting — are intentionally not included.

## Testing
⚠️ Not playtested. `CI=false npm run build` compiles cleanly. Things worth a manual check:
- Pointer-lock dance: `E` to open (cursor frees), assign blocks, `E`/`Esc`/click-outside to close (game resumes) — no stuck "Game Paused".
- A couple of the new tile coordinates are derived from the classic terrain.png layout; glance over the inventory grid to confirm none look wrong for this particular atlas image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)