### PR TITLE
Mining takes time: hold-to-break with crack overlay (#16)

### DIFF
--- a/src/components/UIComponents/PauseOverlay.js
+++ b/src/components/UIComponents/PauseOverlay.js
@@ -5,8 +5,8 @@ const CONTROLS = [
   ["WASD", "Move"],
   ["Space", "Jump"],
   ["Double-tap W", "Sprint"],
-  ["Left click", "Place block"],
-  ["Right click", "Break block"],
+  ["Hold left click", "Break block"],
+  ["Right click", "Place block"],
   ["1-5 / Wheel", "Select block"],
   ["Esc", "Pause"],
 ];

--- a/src/components/cubeComponents/Chunk.jsx
+++ b/src/components/cubeComponents/Chunk.jsx
@@ -22,6 +22,11 @@ export const Chunk = ({
   ]);
 
   function clickCubeFace(e) {
+    // desktop play is driven by MiningController (hold-to-break + place);
+    // this tap handler is only for touch/joystick devices
+    if (!settings.movewithJOY_BOOL) {
+      return;
+    }
     e.stopPropagation();
     var raycaster = new THREE.Raycaster();
     var mouse = new THREE.Vector2();

--- a/src/components/cubeComponents/Cubes.jsx
+++ b/src/components/cubeComponents/Cubes.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { Chunk } from "./Chunk";
+import { MiningController } from "./MiningController";
 import { useFrame, useThree } from "@react-three/fiber";
 import settings from "../../constants";
 import {
@@ -441,18 +442,29 @@ export const Cubes = ({
     activeChunks.current = chunksToDisplay;
   }
 
-  return !FillerLoadDoneValue
-    ? null
-    : chunkKeyList.map((ck) => {
-        return (
-          <Chunk
-            key={`cubechunk${ck}`}
-            chunkKey={ck}
-            chunkProps={chunks}
-            activeTextureREF={activeTextureREF}
-            REF_ALLCUBES={REF_ALLCUBES}
-            applyBlockChange={applyBlockChange}
-          />
-        );
-      });
+  if (!FillerLoadDoneValue) {
+    return null;
+  }
+  return (
+    <>
+      {chunkKeyList.map((ck) => (
+        <Chunk
+          key={`cubechunk${ck}`}
+          chunkKey={ck}
+          chunkProps={chunks}
+          activeTextureREF={activeTextureREF}
+          REF_ALLCUBES={REF_ALLCUBES}
+          applyBlockChange={applyBlockChange}
+        />
+      ))}
+      {/* desktop crosshair mining/placing; mobile uses Chunk's tap handler */}
+      {!settings.movewithJOY_BOOL && (
+        <MiningController
+          applyBlockChange={applyBlockChange}
+          REF_ALLCUBES={REF_ALLCUBES}
+          activeTextureREF={activeTextureREF}
+        />
+      )}
+    </>
+  );
 };

--- a/src/components/cubeComponents/MiningController.jsx
+++ b/src/components/cubeComponents/MiningController.jsx
@@ -1,0 +1,212 @@
+import { useEffect, useMemo, useRef } from "react";
+import { useFrame, useThree } from "@react-three/fiber";
+import * as THREE from "three";
+import settings from "../../constants";
+import { makeKey } from "../../world/keys";
+import { useStore } from "../../hooks/useStore";
+import { makeCrackTextures, CRACK_STAGES } from "../../world/crackTexture";
+
+const REACH = 8; // max block distance you can interact with
+
+// How long (seconds) it takes to break each block type by hand.
+const HARDNESS = {
+  leaves: 0.25,
+  glass: 0.35,
+  grass: 0.55,
+  dirt: 0.55,
+  sand: 0.55,
+  gravel: 0.6,
+  wood: 0.85,
+  log: 0.95,
+  stone: 1.3,
+  cobblestone: 1.35,
+  mossyCobblestone: 1.35,
+  brick: 1.5,
+  ironBlock: 1.6,
+  goldBlock: 1.4,
+  diamondBlock: 1.6,
+  obsidian: 2.5,
+};
+function breakTime(texture) {
+  return HARDNESS[texture] ?? 0.8;
+}
+
+// Centralized, crosshair-based mining for desktop play. Holding the left mouse
+// button breaks the targeted block over ~0.25-2.5s (per block hardness) with a
+// growing crack overlay; right-click places instantly. Mobile/joystick play
+// keeps the existing tap handler in Chunk.jsx.
+export function MiningController({
+  applyBlockChange,
+  REF_ALLCUBES,
+  activeTextureREF,
+}) {
+  const { camera, scene } = useThree();
+  const raycaster = useMemo(() => new THREE.Raycaster(), []);
+  const center = useMemo(() => new THREE.Vector2(0, 0), []);
+  const crackTextures = useMemo(() => makeCrackTextures(), []);
+
+  const overlayRef = useRef();
+  const crackMatRef = useRef();
+  const mining = useRef({ leftDown: false, targetKey: null, progress: 0 });
+
+  const [online_addCube, online_removeCube] = useStore((s) => [
+    s.online_addCube,
+    s.online_removeCube,
+  ]);
+
+  function raycastTarget() {
+    raycaster.setFromCamera(center, camera);
+    const hits = raycaster.intersectObjects(scene.children, true);
+    const hit = hits.find((h) => h.object.name === "cubesMesh2");
+    if (!hit || hit.distance > REACH) {
+      return null;
+    }
+    const n = hit.face.normal;
+    const normal = [n.x, n.y, n.z];
+    const block = [hit.point.x, hit.point.y, hit.point.z].map((v, i) =>
+      Math.round(v + 0.000002 * normal[i] * -1),
+    );
+    return { block, normal };
+  }
+
+  function placeBlock() {
+    const target = raycastTarget();
+    if (!target) {
+      return;
+    }
+    const pos = target.block.map((v, i) => v + target.normal[i]);
+    const texture = activeTextureREF.current;
+
+    // can't place a block inside yourself
+    const [px, py, pz] = camera.position;
+    if (
+      Math.abs(pos[0] - px) < 0.8 &&
+      Math.abs(pos[2] - pz) < 0.8 &&
+      pos[1] > py - 2 &&
+      pos[1] < py + 0.5
+    ) {
+      return;
+    }
+    // don't overwrite an existing solid block
+    const existing = REF_ALLCUBES.current[makeKey(...pos)];
+    if (existing && existing.texture !== "water") {
+      return;
+    }
+    applyBlockChange({ type: "add", pos, texture });
+    if (settings.onlineEnabled) {
+      online_addCube(pos, texture);
+    }
+  }
+
+  function resetMining() {
+    mining.current.targetKey = null;
+    mining.current.progress = 0;
+    if (overlayRef.current) {
+      overlayRef.current.visible = false;
+    }
+  }
+
+  useEffect(() => {
+    if (settings.movewithJOY_BOOL) {
+      return;
+    }
+    function onDown(e) {
+      if (!document.pointerLockElement || useStore.getState().inventoryOpen) {
+        return; // only act while actively playing
+      }
+      if (e.button === 0) {
+        mining.current.leftDown = true;
+      } else if (e.button === 2) {
+        placeBlock();
+      }
+    }
+    function onUp(e) {
+      if (e.button === 0) {
+        mining.current.leftDown = false;
+        resetMining();
+      }
+    }
+    function onLockChange() {
+      if (!document.pointerLockElement) {
+        mining.current.leftDown = false;
+        resetMining();
+      }
+    }
+    window.addEventListener("mousedown", onDown);
+    window.addEventListener("mouseup", onUp);
+    document.addEventListener("pointerlockchange", onLockChange);
+    return () => {
+      window.removeEventListener("mousedown", onDown);
+      window.removeEventListener("mouseup", onUp);
+      document.removeEventListener("pointerlockchange", onLockChange);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useFrame((_, delta) => {
+    const overlay = overlayRef.current;
+    if (!overlay) {
+      return;
+    }
+    const m = mining.current;
+    if (!m.leftDown || settings.movewithJOY_BOOL) {
+      overlay.visible = false;
+      return;
+    }
+
+    const target = raycastTarget();
+    if (!target) {
+      resetMining();
+      return;
+    }
+    const key = makeKey(...target.block);
+    const block = REF_ALLCUBES.current[key];
+    if (!block || block.texture === "bedrock" || block.texture === "water") {
+      resetMining();
+      return;
+    }
+
+    // restart progress whenever the targeted block changes
+    if (key !== m.targetKey) {
+      m.targetKey = key;
+      m.progress = 0;
+    }
+    m.progress += delta / breakTime(block.texture);
+
+    overlay.position.set(target.block[0], target.block[1], target.block[2]);
+    overlay.visible = true;
+    const stage = Math.min(
+      CRACK_STAGES - 1,
+      Math.floor(m.progress * CRACK_STAGES),
+    );
+    if (crackMatRef.current && crackMatRef.current.map !== crackTextures[stage]) {
+      crackMatRef.current.map = crackTextures[stage];
+      crackMatRef.current.needsUpdate = true;
+    }
+
+    if (m.progress >= 1) {
+      applyBlockChange({ type: "remove", pos: target.block });
+      if (settings.onlineEnabled) {
+        online_removeCube(target.block);
+      }
+      // keep breaking the next block if the button is still held
+      m.targetKey = null;
+      m.progress = 0;
+      overlay.visible = false;
+    }
+  });
+
+  return (
+    <mesh ref={overlayRef} visible={false} renderOrder={998}>
+      <boxGeometry args={[1.02, 1.02, 1.02]} />
+      <meshBasicMaterial
+        ref={crackMatRef}
+        map={crackTextures[0]}
+        transparent
+        depthWrite={false}
+        polygonOffset
+        polygonOffsetFactor={-2}
+      />
+    </mesh>
+  );
+}

--- a/src/world/crackTexture.js
+++ b/src/world/crackTexture.js
@@ -1,0 +1,62 @@
+import * as THREE from "three";
+
+// Number of discrete crack stages (Minecraft uses 10; 6 reads fine here).
+export const CRACK_STAGES = 6;
+
+function mulberry32(seed) {
+  let a = seed;
+  return function () {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+// Procedurally draws cumulative crack patterns onto transparent canvases and
+// returns one nearest-filtered THREE texture per break stage. The atlas image
+// is a JPEG with no alpha channel, so its built-in destroy-stage tiles can't
+// be overlaid transparently -- generating cracks here keeps them see-through.
+export function makeCrackTextures() {
+  const size = 64;
+  const rng = mulberry32(0x9e3779b1);
+
+  // a fixed pool of crack segments; each stage reveals progressively more
+  const total = 26;
+  const segments = [];
+  for (let i = 0; i < total; i++) {
+    const x0 = rng() * size;
+    const y0 = rng() * size;
+    const ang = rng() * Math.PI * 2;
+    const len = 8 + rng() * 20;
+    segments.push([x0, y0, x0 + Math.cos(ang) * len, y0 + Math.sin(ang) * len]);
+  }
+
+  const textures = [];
+  for (let s = 0; s < CRACK_STAGES; s++) {
+    const canvas = document.createElement("canvas");
+    canvas.width = canvas.height = size;
+    const ctx = canvas.getContext("2d");
+    ctx.clearRect(0, 0, size, size);
+    ctx.strokeStyle = "rgba(0, 0, 0, 0.65)";
+    ctx.lineWidth = 2;
+    ctx.lineCap = "round";
+
+    const count = Math.ceil(((s + 1) / CRACK_STAGES) * total);
+    for (let i = 0; i < count; i++) {
+      const [a, b, c, d] = segments[i];
+      ctx.beginPath();
+      ctx.moveTo(a, b);
+      ctx.lineTo(c, d);
+      ctx.stroke();
+    }
+
+    const tex = new THREE.CanvasTexture(canvas);
+    tex.magFilter = THREE.NearestFilter;
+    tex.minFilter = THREE.NearestFilter;
+    tex.generateMipmaps = false;
+    textures.push(tex);
+  }
+  return textures;
+}


### PR DESCRIPTION
Closes #16.

Changes block breaking from instant click-spam to Minecraft's deliberate hold-to-break, and switches to the Minecraft control convention (this is what the issue asks for).

## Behavior
- **Hold left mouse** to break the targeted block. Break time scales with **block hardness** (~0.25s for leaves up to ~2.5s for obsidian; default 0.8s).
- A **crack overlay** grows across the block face as you mine; it **resets if the target changes** (you look at a different block) or you release.
- Holding the button keeps breaking the **next** block automatically.
- **Right click** places a block instantly.

## Implementation
- New **`MiningController`** (`cubeComponents/MiningController.jsx`), mounted from `Cubes.jsx` for **desktop** play. It raycasts from the crosshair every frame and owns place/break under pointer lock, with a `HARDNESS` table for per-block timing.
- `Chunk.jsx`'s old tap handler is now **touch/joystick-only**, so desktop interaction isn't double-handled.
- **`crackTexture.js`** procedurally draws cumulative crack stages onto transparent canvas textures. The atlas image is a JPEG with **no alpha channel**, so its built-in destroy-stage tiles can't be overlaid transparently — generating cracks keeps them see-through. The overlay is a slightly-enlarged box with `polygonOffset` to avoid z-fighting.
- Mining state is cleared on mouseup and on losing pointer lock, so you never resume mid-break after pausing.
- `PauseOverlay` control hints updated to "Hold left click → Break / Right click → Place".

## Note on controls
The repo previously had **left = place, right = break**. The issue explicitly asks for **hold-left = break, right = place** (Minecraft style), so this PR flips them. If you'd rather keep the old mapping, it's a one-line swap in `MiningController`.

## Testing
⚠️ Not playtested. `CI=false npm run build` compiles cleanly. Manual checks: hold to break (crack grows, block pops), look away mid-break (resets), right-click to place, and confirm mobile/joystick break+place still works via the Chunk tap path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)