### PR TITLE
Sun, moon, stars + day/night lighting; remove skybox (#33)

### DIFF
--- a/src/components/effects/DayNight.jsx
+++ b/src/components/effects/DayNight.jsx
@@ -1,58 +1,150 @@
-import { Sky } from "@react-three/drei";
 import { useFrame, useThree } from "@react-three/fiber";
-import { useRef, useState } from "react";
+import { useMemo, useRef } from "react";
 import * as THREE from "three";
 
 const DAY_LENGTH_S = 2400; // full day/night cycle (40 min)
 const DAY_FOG = new THREE.Color("#d7e7f5");
-const NIGHT_FOG = new THREE.Color("#070b14");
+const NIGHT_FOG = new THREE.Color("#0a0f1c");
+const DAY_SKY = new THREE.Color("#88c0ff"); // overhead daytime blue
+const NIGHT_SKY = new THREE.Color("#05070f");
 
-// Drives the sun: a directional light + ambient light + the drei Sky dome,
-// and tints the scene fog/background from day to night. Lights are mutated
-// per frame via refs; the Sky component re-renders on a slow tick.
+const SKY_DIST = 150; // how far the sun/moon/stars sit from the player
+
+// Drives the sky: sun + moon directional lights, ambient fill, and the sun,
+// moon and star meshes that ride across the sky. The old drei <Sky> dome is
+// gone (it never darkened at night); the background color is lerped from a
+// daytime blue to near-black instead, with stars fading in after dusk.
 export function DayNight({ showSky }) {
   const { scene } = useThree();
-  const sunRef = useRef();
+  const sunLightRef = useRef();
+  const moonLightRef = useRef();
   const ambRef = useRef();
-  const fogColor = useRef(new THREE.Color().copy(DAY_FOG));
-  const lastSkyTick = useRef(0);
-  const [sunPos, setSunPos] = useState([80, 60, 20]);
+  const skyGroupRef = useRef();
+  const sunMeshRef = useRef();
+  const moonMeshRef = useRef();
+  const starsMatRef = useRef();
 
-  useFrame(({ clock }) => {
+  const fogColor = useRef(new THREE.Color().copy(DAY_FOG));
+  const bgColor = useRef(new THREE.Color().copy(DAY_SKY));
+
+  // a fixed dome of stars, generated once
+  const starGeom = useMemo(() => {
+    const g = new THREE.BufferGeometry();
+    const N = 900;
+    const arr = new Float32Array(N * 3);
+    for (let i = 0; i < N; i++) {
+      const theta = Math.random() * Math.PI * 2;
+      const phi = Math.acos(2 * Math.random() - 1);
+      const r = SKY_DIST * 0.98;
+      arr[i * 3] = r * Math.sin(phi) * Math.cos(theta);
+      arr[i * 3 + 1] = Math.abs(r * Math.cos(phi)) * 0.85 + 8; // bias above horizon
+      arr[i * 3 + 2] = r * Math.sin(phi) * Math.sin(theta);
+    }
+    g.setAttribute("position", new THREE.BufferAttribute(arr, 3));
+    return g;
+  }, []);
+
+  useFrame(({ clock, camera }) => {
     const t = clock.getElapsedTime();
     // start mid-morning so new games begin in daylight
     const angle = (t / DAY_LENGTH_S) * Math.PI * 2 + Math.PI / 5;
     const sin = Math.sin(angle);
-    const pos = [Math.cos(angle) * 100, sin * 100, 20];
+    const cos = Math.cos(angle);
+
+    // unit sun direction (slightly tilted off the x/y plane)
+    const sx = cos;
+    const sy = sin;
+    const sz = 0.25;
+    const len = Math.hypot(sx, sy, sz);
+    const ux = sx / len;
+    const uy = sy / len;
+    const uz = sz / len;
+
     // 0 = night, 1 = day, with a quick dawn/dusk transition
     const dayness = THREE.MathUtils.clamp(sin * 3, -1, 1) * 0.5 + 0.5;
+    const nightness = 1 - dayness;
 
-    if (sunRef.current) {
-      sunRef.current.position.set(pos[0], pos[1], pos[2]);
-      sunRef.current.intensity = 0.55 * dayness;
+    if (sunLightRef.current) {
+      sunLightRef.current.position.set(ux * 100, uy * 100, uz * 100);
+      sunLightRef.current.intensity = 0.7 * dayness;
+    }
+    if (moonLightRef.current) {
+      // moonlight comes from the opposite side; keeps nights navigable
+      moonLightRef.current.position.set(-ux * 100, -uy * 100, -uz * 100);
+      moonLightRef.current.intensity = 0.28 * nightness;
     }
     if (ambRef.current) {
-      ambRef.current.intensity = 0.3 + 0.25 * dayness;
+      // never fully dark, so caves/nights stay playable
+      ambRef.current.intensity = 0.22 + 0.4 * dayness;
     }
 
     fogColor.current.copy(NIGHT_FOG).lerp(DAY_FOG, dayness);
     if (scene.fog) {
       scene.fog.color.copy(fogColor.current);
     }
-    scene.background = fogColor.current;
+    bgColor.current.copy(NIGHT_SKY).lerp(DAY_SKY, dayness);
+    scene.background = bgColor.current;
 
-    // the Sky dome only needs coarse updates
-    if (t - lastSkyTick.current > 0.5) {
-      lastSkyTick.current = t;
-      setSunPos(pos);
+    // keep the celestial dome centered on the player so it reads as infinitely
+    // far (no parallax as you walk)
+    if (skyGroupRef.current) {
+      skyGroupRef.current.position.copy(camera.position);
+    }
+    if (sunMeshRef.current) {
+      sunMeshRef.current.position.set(
+        ux * SKY_DIST,
+        uy * SKY_DIST,
+        uz * SKY_DIST,
+      );
+    }
+    if (moonMeshRef.current) {
+      moonMeshRef.current.position.set(
+        -ux * SKY_DIST,
+        -uy * SKY_DIST,
+        -uz * SKY_DIST,
+      );
+    }
+    if (starsMatRef.current) {
+      starsMatRef.current.opacity = THREE.MathUtils.clamp(
+        nightness * 1.4 - 0.1,
+        0,
+        1,
+      );
     }
   });
 
   return (
     <>
-      {showSky && <Sky sunPosition={sunPos} />}
-      <ambientLight ref={ambRef} intensity={0.65} />
-      <directionalLight ref={sunRef} position={sunPos} intensity={0.9} />
+      <ambientLight ref={ambRef} intensity={0.5} />
+      <directionalLight ref={sunLightRef} intensity={0.9} color="#fff4d6" />
+      <directionalLight ref={moonLightRef} intensity={0} color="#8aa0d8" />
+      {showSky && (
+        <group ref={skyGroupRef}>
+          {/* sun */}
+          <mesh ref={sunMeshRef}>
+            <sphereGeometry args={[9, 20, 20]} />
+            <meshBasicMaterial color="#fff2a8" fog={false} toneMapped={false} />
+          </mesh>
+          {/* moon */}
+          <mesh ref={moonMeshRef}>
+            <sphereGeometry args={[6, 20, 20]} />
+            <meshBasicMaterial color="#e6ecf5" fog={false} toneMapped={false} />
+          </mesh>
+          {/* stars */}
+          <points geometry={starGeom}>
+            <pointsMaterial
+              ref={starsMatRef}
+              size={1.5}
+              color="#ffffff"
+              sizeAttenuation
+              transparent
+              opacity={0}
+              depthWrite={false}
+              fog={false}
+            />
+          </points>
+        </group>
+      )}
     </>
   );
 }


### PR DESCRIPTION
Addresses **#33** (scoped — see the note below).

Reworks the sky and lighting in `DayNight.jsx`.

## What's included
- **Sun & moon** discs that ride across the sky on the day/night cycle, parented to a player-centered group so they read as infinitely far (no parallax as you walk). Materials use `fog={false}` so the short render fog doesn't hide them.
- **Stars** — a generated star dome that fades in after dusk and out at dawn.
- **Day/night drives the lighting**: a warm sun directional light by day, a cool **moon directional light** + an **ambient floor** at night so nights (and caves) stay navigable instead of pitch black.
- **Skybox removed** — the drei `<Sky>` dome never darkened at night (the issue literally suggests "might be best to remove it"). The background color now lerps from daytime blue to near-black, matching the fog.

## Scope note (important)
The issue also asks for a full Minecraft-style **per-block light level** system and **placeable torches**. I deliberately left those out of this PR: light propagation (BFS flood-fill across an infinite, web-worker-chunked world) and inserting non-cube torch geometry into the meshing pipeline are large, invasive changes that are risky to land **without in-engine testing**. They deserve their own focused PR. This PR does **not** auto-close #33.

## Testing
⚠️ Not playtested. `CI=false npm run build` compiles cleanly. Worth checking in-engine: sun/moon track across the sky, stars appear at night, nights are dark-but-playable, and there's no leftover bright skybox at night. If the sun/moon ever fail to render, the only likely cause is the camera's far plane — bump `SKY_DIST` down or set the Canvas camera `far` higher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)