### PR TITLE
Water lowers its height as it flows (#35)

### DIFF
--- a/src/world/meshGen.js
+++ b/src/world/meshGen.js
@@ -24,6 +24,17 @@ function isTransparent(texture) {
   return TRANSPARENT_TEXTURES.includes(texture);
 }
 
+// Surface height (fraction of a full block, 0..1) for a water cell, by how far
+// it has flowed. Generated source water has no `flow` field and sits near full;
+// flowing water (flow 1..4, set in Cubes.jsx's water sim, 4 = strongest) lowers
+// its surface the further it has spread -- so streams visibly slope downhill.
+function waterTopFrac(flow) {
+  if (flow == null) {
+    return 0.9; // source / falling water -- effectively a full block
+  }
+  return 0.3 + 0.55 * ((flow - 1) / 3);
+}
+
 // A face is hidden when its neighbor fully covers it:
 // - opaque blocks cull against opaque neighbors
 // - transparent blocks cull against the same texture (water-water,
@@ -72,6 +83,19 @@ export function genFaceArrays(t, blocks, chunkBlocks) {
     c[6] = [x - t, y - t, z - t];
     c[7] = [x - t, y + t, z - t];
     c[8] = [x + t, y + t, z - t];
+
+    // a water cell with air above is a surface cell -- drop its top (and the
+    // top edges of its side faces) so flowing water reads as a sloping stream
+    if (texture === "water") {
+      const above = blocks[makeKey(nx, ny + t2, nz)];
+      if (!above || above.texture !== "water") {
+        const topY = y - t + t2 * waterTopFrac(block.flow);
+        c[3][1] = topY;
+        c[4][1] = topY;
+        c[7][1] = topY;
+        c[8][1] = topY;
+      }
+    }
 
     function pushFace(corners, normal, face, shade) {
       target.vertices.push(...corners[0], ...corners[1], ...corners[2]);


### PR DESCRIPTION
Addresses **#35** (scoped — see notes).

## What this PR does
Implements the issue's "**water should lower its height as it flows further away**" requirement in the renderer (`src/world/meshGen.js`):

- A water cell with **air above it** is a surface cell, so its **top face (and the top edges of its side faces) drop down**.
- The drop scales with the cell's **flow strength**, which the water simulation in `Cubes.jsx` already tracks (`flow` 1..4, decremented each cell as it spreads; source/falling water is full). `waterTopFrac()` maps that to a surface height.
- Result: streams visibly slope downhill / sit below source pools instead of every water block being a full cube.

The data was already there — water cells carry their `flow` value into the worker mesh payload — this PR just uses it.

## Already in place (from the existing flow sim)
- A **max flow distance** (`FLOW_RANGE = 4`) and per-cell strength decrement — the issue's "max distance it can flow" is already implemented; this PR makes it visible.

## Not changed (and why)
- **"Players can't sink more than 1 block"**: I reviewed the swim physics in `Player.js` and couldn't find a bug — sinking is clamped to a gentle rate but does reach the floor. The symptom is most likely that **generated water on `master` is shallow** (often 1 block deep at sea level). Deeper water comes with the ocean biome (#36). I deliberately left the physics untouched rather than risk breaking swim movement I can't playtest.

## Testing
⚠️ Not playtested. `CI=false npm run build` compiles cleanly. Manual check: break a block at the edge of a pool so water flows out and down a step — the flowing cells should sit lower than the source. Minor known artifact: adjacent surface cells with different flow levels share a culled face, so the surface "steps" rather than smoothly slopes; fine for a clone, easy to refine later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)