### PR TITLE
Proper initial loading screen (#52)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,10 +3,105 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
+    <meta name="theme-color" content="#1a1a1a" />
     <title>KNG's MC Clone</title>
+    <style>
+      /* Initial boot splash. This is inline (no bundle, no React) so something
+         themed shows the instant the page loads, instead of a blank white
+         flash while the JS chunk downloads and React mounts. index.js fades
+         and removes #boot-splash once the app has rendered. */
+      #boot-splash {
+        position: fixed;
+        inset: 0;
+        z-index: 9999;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        font-family: "Courier New", Courier, monospace;
+        /* CSS-only dirt-ish texture so we need no bundled image asset */
+        background-color: #6b4f34;
+        background-image:
+          linear-gradient(45deg, #5e452d 25%, transparent 25%, transparent 75%, #5e452d 75%),
+          linear-gradient(45deg, #5e452d 25%, transparent 25%, transparent 75%, #5e452d 75%);
+        background-size: 16px 16px;
+        background-position: 0 0, 8px 8px;
+        transition: opacity 0.5s ease;
+      }
+      #boot-splash::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background: rgba(0, 0, 0, 0.7);
+      }
+      #boot-splash.boot-splash--hide {
+        opacity: 0;
+        pointer-events: none;
+      }
+      .boot-splash__inner {
+        position: relative;
+        z-index: 1;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        width: min(360px, 86vw);
+      }
+      .boot-splash__logo {
+        font-size: clamp(26px, 8vw, 52px);
+        font-weight: bold;
+        letter-spacing: 3px;
+        text-transform: uppercase;
+        color: #fff;
+        text-shadow: 3px 3px 0 #3a3a3a, 5px 5px 0 #000;
+        margin: 0 0 22px 0;
+        text-align: center;
+      }
+      .boot-splash__bar {
+        position: relative;
+        width: 100%;
+        height: 22px;
+        background: #111;
+        border: 3px solid #555;
+        border-top-color: #222;
+        border-left-color: #222;
+        border-bottom-color: #888;
+        border-right-color: #888;
+        overflow: hidden;
+      }
+      /* indeterminate sweep -- real progress isn't known until React is up
+         and the chunk loader takes over with its own "Building world" bar */
+      .boot-splash__bar::after {
+        content: "";
+        display: block;
+        height: 100%;
+        width: 40%;
+        background: linear-gradient(to bottom, #7ec850 0%, #5aaa30 49%, #48921e 50%, #5aaa30 100%);
+        animation: boot-splash-sweep 1.1s ease-in-out infinite;
+      }
+      .boot-splash__label {
+        margin-top: 12px;
+        font-size: 12px;
+        font-weight: bold;
+        letter-spacing: 2px;
+        color: #ddd;
+        text-shadow: 1px 1px 0 #000;
+        text-transform: uppercase;
+      }
+      @keyframes boot-splash-sweep {
+        0% { transform: translateX(-110%); }
+        100% { transform: translateX(310%); }
+      }
+    </style>
   </head>
   <body>
+    <!-- Shown immediately; faded out and removed from index.js after mount. -->
+    <div id="boot-splash">
+      <div class="boot-splash__inner">
+        <h1 class="boot-splash__logo">KNG's MC Clone</h1>
+        <div class="boot-splash__bar"></div>
+        <div class="boot-splash__label">Loading&hellip;</div>
+      </div>
+    </div>
     <div id="root"></div>
   </body>
 </html>

--- a/src/index.js
+++ b/src/index.js
@@ -9,3 +9,18 @@ root.render(
     <App />
   </React.StrictMode>
 );
+
+// Fade out and remove the inline boot splash (see public/index.html) once the
+// app has rendered. Two rAFs ensure the title screen has painted underneath
+// before the splash starts fading, so there's never a blank frame between.
+function dismissBootSplash() {
+  const splash = document.getElementById('boot-splash');
+  if (!splash) {
+    return;
+  }
+  splash.classList.add('boot-splash--hide');
+  splash.addEventListener('transitionend', () => splash.remove(), { once: true });
+  // fallback in case the transition event never fires
+  setTimeout(() => splash.remove(), 800);
+}
+requestAnimationFrame(() => requestAnimationFrame(dismissBootSplash));


### PR DESCRIPTION
Closes #52.

## What this PR does
Adds a **pre-React boot splash** so the page shows a themed loading screen the instant it loads, instead of the current blank/white flash while the JS bundle downloads and React mounts.

- The splash markup + styles live **inline in `public/index.html`** (no bundle, no React, no image asset), so they render on the very first paint. It uses a CSS-only dirt-tone pattern and an indeterminate green progress sweep to match the game's Minecraft aesthetic.
- `src/index.js` fades it out and removes it once the app has rendered (two `requestAnimationFrame`s so the title screen has painted underneath first — no blank frame between). A `setTimeout` fallback guarantees removal even if `transitionend` never fires.

## Hand-off to the existing world loader
This only covers the **boot** gap (bundle download → first React paint). Once the player picks a world, the existing `LoadingWorldScreen` ("Building world…", real % bar) takes over for chunk generation — that part was already in place. The two now form a continuous loading experience from cold load to spawn.

## Testing
⚠️ Not playtested in-browser. `CI=false npm run build` compiles cleanly and the splash HTML is emitted into `build/index.html`. Manual check: hard-reload with cache disabled — the dirt splash with the sweeping bar should appear immediately and fade out as the title screen appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)