### PR TITLE
Allow natural surface cave entrances (#54)

### DIFF
--- a/src/workers/chunkWorker.js
+++ b/src/workers/chunkWorker.js
@@ -34,6 +34,10 @@ function initializeWorker(init) {
   worldSet.contNoise = createNoise2D(alea(worldSet.seed + "-cont")); // land/ocean
   worldSet.tempNoise = createNoise2D(alea(worldSet.seed + "-temp")); // desert/plains
   worldSet.detailNoise = createNoise2D(alea(worldSet.seed + "-detail"));
+  // low-frequency mask that decides, per column, whether caves are allowed to
+  // breach the surface skin (see entranceCapDepth) -- so openings cluster into
+  // a few natural regions instead of pocking the whole map
+  worldSet.entranceNoise = createNoise2D(alea(worldSet.seed + "-entrance"));
   worldSet.seedNum = String(worldSet.seed)
     .split("")
     .reduce((a, c) => a + c.charCodeAt(0) * 31, 7);
@@ -61,6 +65,38 @@ const CHEESE_THRESHOLD = 0.4; // smaller -> more open volume carved out
 // Spaghetti tunnels -- thin passages that connect the rooms.
 const TUNNEL_SCALE = 1 / 40; // larger divisor -> wider, more spread-out tunnels
 const TUNNEL_THRESHOLD = 0.06; // larger -> wider/more tunnels
+
+// Surface cave entrances. By default columnBlocks preserves the top
+// SURFACE_CAP blocks so caves never breach the surface. In rare regions
+// picked by entranceNoise we lift that cap toward 0 so caves that happen to
+// reach the surface punch a natural, walkable opening -- making caves
+// discoverable without digging straight down. Spawn stays protected.
+const SURFACE_CAP = 4; // blocks of surface skin kept solid where no entrance
+const ENTRANCE_SCALE = 1 / 130; // larger divisor -> bigger, rarer entrance zones
+const ENTRANCE_THRESHOLD = 0.66; // higher -> fewer columns eligible for openings
+const ENTRANCE_FEATHER = 0.16; // noise band over which the cap ramps 4 -> 0
+const SPAWN_SAFE_RADIUS = 32; // no entrances within this many blocks of origin
+const SPAWN_SAFE_FEATHER = 24; // entrances ramp back in over this outer band
+
+// How many surface blocks to keep solid at column (x,z). Normally SURFACE_CAP;
+// drops toward 0 inside entrance regions (and only well away from spawn) so
+// caves there can open to the sky.
+function entranceCapDepth(x, z) {
+  const m = (worldSet.entranceNoise(x * ENTRANCE_SCALE, z * ENTRANCE_SCALE) + 1) / 2;
+  const inRegion = smoothstep(
+    ENTRANCE_THRESHOLD,
+    ENTRANCE_THRESHOLD + ENTRANCE_FEATHER,
+    m,
+  );
+  const dist = Math.hypot(x, z);
+  const awayFromSpawn = smoothstep(
+    SPAWN_SAFE_RADIUS,
+    SPAWN_SAFE_RADIUS + SPAWN_SAFE_FEATHER,
+    dist,
+  );
+  const strength = inRegion * awayFromSpawn; // 0 = capped, 1 = fully open
+  return Math.round(SURFACE_CAP * (1 - strength));
+}
 
 function isCave(x, y, z) {
   // open cheese cavern
@@ -173,11 +209,17 @@ function columnBlocks(x, z, info, infoList) {
   // sand surface in deserts, on ocean/lake floors, and on beaches near water
   const sandy = biome === DESERT || biome === OCEAN || h <= waterLevel + 1;
 
+  // how much surface skin stays solid: full cap underwater/on beaches (keeps
+  // ocean floors intact), but reduced inland inside rare entrance regions so
+  // caves can break the surface there
+  const cap =
+    h > waterLevel + 1 ? entranceCapDepth(x, z) : SURFACE_CAP;
+
   for (let y = minY; y <= h; y++) {
-    // carve caves out of the stone interior: skip the surface skin (top 4
-    // blocks) so terrain stays capped, and keep bedrock + one block above it
-    // as a solid floor so caves never bottom out into the void
-    if (y > minY + 1 && y <= h - 4 && isCave(x, y, z)) {
+    // carve caves out of the stone interior: skip the preserved surface skin
+    // (cap blocks, normally 4) so terrain stays capped, and keep bedrock + one
+    // block above it as a solid floor so caves never bottom out into the void
+    if (y > minY + 1 && y <= h - cap && isCave(x, y, z)) {
       continue;
     }
     let texture;


### PR DESCRIPTION
Closes #54.

## Background
Cave generation preserved the top **4 surface blocks** of every column unconditionally (the `y <= h - 4` cap in `columnBlocks`), so caves never broke the surface — they could only be found by digging straight down. #54 asks to relax this safely so some caves have discoverable openings, without compromising spawn.

## What this PR does
Adds a low-frequency **`entranceNoise`** mask and a new `entranceCapDepth(x, z)` helper in `src/workers/chunkWorker.js`:

- In **rare regions** picked by the mask (above `ENTRANCE_THRESHOLD`), the preserved surface cap ramps from **4 → 0**, so any cave that reaches the surface there carves a real opening.
- Edges are **feathered** with `smoothstep`, so entrances blend into the terrain instead of forming hard-edged gashes.
- **Spawn stays safe**: the cap is never reduced within `SPAWN_SAFE_RADIUS` (32 blocks) of the world origin, ramping back in over an outer band.
- **Land only**: underwater columns and beaches keep the full cap, so ocean floors stay intact and we don't create dry air pockets under the sea.

Everything stays a pure function of position, so entrances are deterministic and seamless across chunk borders (no new cross-chunk bookkeeping).

## Tunables
`SURFACE_CAP`, `ENTRANCE_SCALE`, `ENTRANCE_THRESHOLD`, `ENTRANCE_FEATHER`, `SPAWN_SAFE_RADIUS`, `SPAWN_SAFE_FEATHER` — all grouped next to the existing cave constants. Values are deliberately conservative (entrances are uncommon); bump `ENTRANCE_THRESHOLD` down / `ENTRANCE_SCALE` for more, larger openings.

## Testing
⚠️ Not playtested — tuning is best eyeballed in-engine. `CI=false npm run build` compiles cleanly. Known minor artifact: a tree could occasionally root over an opening (trees are placed from `surfaceHeight`, independent of carving); rare given how sparse both are.

🤖 Generated with [Claude Code](https://claude.com/claude-code)