### PR TITLE
Smooth water surface between flow levels (#55)

### DIFF
--- a/src/world/meshGen.js
+++ b/src/world/meshGen.js
@@ -35,6 +35,46 @@ function waterTopFrac(flow) {
   return 0.3 + 0.55 * ((flow - 1) / 3);
 }
 
+// Surface fraction of the water cell at (nx,ny,nz), or null if that column
+// isn't a water *surface* cell at this level (not water, or submerged with
+// water directly above). Used to average corner heights between neighbours so
+// the surface slopes smoothly instead of stepping between flow levels.
+function waterSurfaceFracAt(blocks, nx, ny, nz, t2) {
+  const cell = blocks[makeKey(nx, ny, nz)];
+  if (!cell || cell.texture !== "water") {
+    return null;
+  }
+  const above = blocks[makeKey(nx, ny + t2, nz)];
+  if (above && above.texture === "water") {
+    return null; // submerged -- its surface is higher up, not here
+  }
+  return waterTopFrac(cell.flow);
+}
+
+// Height of a water surface corner, averaged over the (up to 4) surface water
+// columns that meet at it. dx/dz pick which diagonal corner (each ±1 in block
+// units). The cell itself always contributes, so a corner shared by cells of
+// different flow lands halfway between them -- turning the per-cell steps into
+// a continuous sloped surface.
+function waterCornerY(blocks, nx, ny, nz, dx, dz, y, t, t2) {
+  let sum = 0;
+  let count = 0;
+  for (const [ox, oz] of [
+    [0, 0],
+    [dx * t2, 0],
+    [0, dz * t2],
+    [dx * t2, dz * t2],
+  ]) {
+    const frac = waterSurfaceFracAt(blocks, nx + ox, ny, nz + oz, t2);
+    if (frac != null) {
+      sum += frac;
+      count++;
+    }
+  }
+  const frac = count > 0 ? sum / count : waterTopFrac(null);
+  return y - t + t2 * frac;
+}
+
 // A face is hidden when its neighbor fully covers it:
 // - opaque blocks cull against opaque neighbors
 // - transparent blocks cull against the same texture (water-water,
@@ -85,15 +125,17 @@ export function genFaceArrays(t, blocks, chunkBlocks) {
     c[8] = [x + t, y + t, z - t];
 
     // a water cell with air above is a surface cell -- drop its top (and the
-    // top edges of its side faces) so flowing water reads as a sloping stream
+    // top edges of its side faces). Each top corner is averaged with the
+    // neighbouring surface cells that meet there, so adjacent flow levels
+    // slope into each other smoothly instead of stepping. Corners c3/c4/c7/c8
+    // are shared by the top and the side faces, so the side tops follow too.
     if (texture === "water") {
       const above = blocks[makeKey(nx, ny + t2, nz)];
       if (!above || above.texture !== "water") {
-        const topY = y - t + t2 * waterTopFrac(block.flow);
-        c[3][1] = topY;
-        c[4][1] = topY;
-        c[7][1] = topY;
-        c[8][1] = topY;
+        c[3][1] = waterCornerY(blocks, nx, ny, nz, -1, 1, y, t, t2); // -x +z
+        c[4][1] = waterCornerY(blocks, nx, ny, nz, 1, 1, y, t, t2); //  +x +z
+        c[7][1] = waterCornerY(blocks, nx, ny, nz, -1, -1, y, t, t2); // -x -z
+        c[8][1] = waterCornerY(blocks, nx, ny, nz, 1, -1, y, t, t2); //  +x -z
       }
     }
 


### PR DESCRIPTION
Closes #55.

> ⚠️ **Stacked on #47** — this PR's base is `feat/35-water`, so it only shows the smoothing diff on top of the flow-height work. Review/merge #47 first, then this (or retarget to `master` once #47 lands).

## Background
#47 dropped each water surface cell's top by its own flow strength. Because adjacent surface cells of different flow share a culled water–water face, the surface **stepped** down between flow levels instead of sloping — flagged there as an easy-to-refine artifact.

## What this PR does
Replaces the uniform per-cell top with **per-corner height averaging** in `src/world/meshGen.js`:

- `waterSurfaceFracAt()` returns a column's surface fraction, or `null` if it isn't a surface water cell at that level (not water, or submerged with water above).
- `waterCornerY()` averages each of a surface cell's 4 top corners over the (up to 4) surface water columns that meet at it. A corner shared by a strong-flow and weak-flow cell lands halfway between them.
- The four shared top corners (`c3/c4/c7/c8`) feed both the top face and the side-face tops, so the whole surface becomes **continuous** rather than stepped.

Averaging is **per-level**, so true vertical drops (waterfalls off a ledge) keep their hard edge — only same-height neighbours blend.

## Testing
⚠️ Not playtested. `CI=false npm run build` compiles cleanly. Manual check: let water flow out across a flat area — the surface should slope smoothly from the source down to the flow edge instead of dropping in visible stair-steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)