### PR TITLE
Water: player can't sink >1 block in deep water (#48)

### DIFF
--- a/src/components/playerComponents/Player.js
+++ b/src/components/playerComponents/Player.js
@@ -174,16 +174,25 @@ export const Player = ({ moveBools, playerStartingPostion, REF_ALLCUBES }) => {
     movementStatus.current.inWater = inWater;
 
     if (!movementStatus.current.flying) {
-      //check vertical limits
-      if (!surrData.surroundingBlocks.b) {
+      // check vertical limits. A block 2 below only keeps us grounded if it's
+      // actually solid -- water (and the other "air" floor types) must NOT
+      // count. Otherwise standing over deep water leaves onGround stuck true
+      // (water blocks ARE present in the map, so the old `!b` test saw support)
+      // and the sink branch below never ran -- the "can't sink in water" bug
+      // (#48). Now water below correctly drops us into the swim path.
+      const belowKey = surrData.surroundingBlocks.b;
+      const belowBlock = belowKey ? REF_ALLCUBES.current[belowKey] : null;
+      const belowIsSolid =
+        belowBlock && !blocktypes.floor.air.includes(belowBlock.texture);
+      if (!belowIsSolid) {
         movementStatus.current.onGround = false;
       }
 
       if (!movementStatus.current.onGround) {
         vel_y += GRAVITY * dt;
-        // water: sink slowly, swim up with jump
+        // water: sink steadily toward the floor, swim up while holding jump
         if (inWater) {
-          const maxSink = -2;
+          const maxSink = -2.5;
           vel_y = vel_y < maxSink ? maxSink : vel_y;
           if (jump.on || moveBools.current.jump) {
             vel_y = 3;


### PR DESCRIPTION
Closes #48.

## Root cause found
The symptom — *"players can't sink more than ~1 block in water"* — is a real bug in `Player.js`, not just the shallow-water artifact #47 suspected.

`worldPhysicsController` cleared `onGround` only when the block **2 below** the player was *absent*:

```js
if (!surrData.surroundingBlocks.b) {
  movementStatus.current.onGround = false;
}
```

But **water blocks are present in the world map** (they're real entries in `REF_ALLCUBES`), so when you float over deep water `surroundingBlocks.b` is truthy → `onGround` stays stuck `true` → the whole sink/swim branch is skipped (`else { vel_y = 0 }`) and you hover at the surface. On `master` this was masked because water was usually only 1 block deep; the deep **ocean biome** (#36 / #41) exposes it.

## Fix
Treat the block below as support **only when it's actually solid** — not one of the `floor.air` liquid/air textures (water):

```js
const belowBlock = belowKey ? REF_ALLCUBES.current[belowKey] : null;
const belowIsSolid = belowBlock && !blocktypes.floor.air.includes(belowBlock.texture);
if (!belowIsSolid) movementStatus.current.onGround = false;
```

Now water below correctly drops the player into the swim path: you sink steadily (nudged from -2 to **-2.5 blocks/s**) to the seabed and swim back up by holding jump. The seabed (solid) still grounds you normally, and behaviour on land is unchanged (a solid block below is still support).

## On the second half of #35 ("water doesn't flow into empty spaces")
Reviewed the flow sim in `Cubes.jsx` (`tickWaterFlow`) after #47: water falls into empty cells below and spreads sideways up to `FLOW_RANGE` when blocked — including into holes you dig (`enqueueFlowAround` on removal). It behaves as intended, so no change here.

## Testing
⚠️ Not playtested. `CI=false npm run build` compiles cleanly. Manual check: jump into a deep ocean and stop holding keys — you should sink all the way to the seabed; hold Space to rise back to the surface. Confirm walking on land and standing on block edges is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)